### PR TITLE
fix: Safari card sizing in grid layouts

### DIFF
--- a/src/svelte/components/HomepageSSR.svelte
+++ b/src/svelte/components/HomepageSSR.svelte
@@ -610,10 +610,12 @@
   /* --- POSTER GRID --- */
   .poster-row {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
     gap: 16px;
+    align-items: start; /* Prevent vertical stretching of grid items */
   }
   .poster-row :global(> *) {
+    width: 100%;
     max-width: 220px;
     justify-self: center;
   }
@@ -621,7 +623,7 @@
   /* On wider screens, allow cards to grow larger and fill space */
   @media (min-width: 1400px) {
     .poster-row {
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     }
     .poster-row :global(> *) {
       max-width: 240px;
@@ -630,7 +632,7 @@
 
   @media (min-width: 1800px) {
     .poster-row {
-      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
     }
     .poster-row :global(> *) {
       max-width: 260px;

--- a/src/svelte/components/PosterCard.svelte
+++ b/src/svelte/components/PosterCard.svelte
@@ -93,12 +93,14 @@
   .poster-card {
     display: flex;
     flex-direction: column;
+    width: 100%;
     cursor: pointer;
     text-decoration: none;
     color: inherit;
   }
   .poster {
     aspect-ratio: 2/3;
+    width: 100%;
     border-radius: var(--weeb-radius, 8px);
     background: var(--weeb-surface);
     overflow: hidden;

--- a/src/svelte/components/ProfilePage.svelte
+++ b/src/svelte/components/ProfilePage.svelte
@@ -845,7 +845,7 @@
   .section-link:hover { color: var(--weeb-accent-hover); }
 
   /* ── Anime grid ─────────────────────────────────────────────── */
-  .anime-grid { display: grid; gap: 16px; }
+  .anime-grid { display: grid; gap: 16px; align-items: start; }
   .anime-grid--3col {
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   }
@@ -899,7 +899,6 @@
     overflow: hidden;
   }
   .skeleton-poster {
-    width: 100%;
     aspect-ratio: 2 / 3;
     background: var(--weeb-surface-hover, var(--weeb-surface));
   }

--- a/src/svelte/components/SearchPage.svelte
+++ b/src/svelte/components/SearchPage.svelte
@@ -1093,6 +1093,7 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
     gap: 20px;
+    align-items: start;
   }
   .results-grid :global(.poster-card) {
     max-width: 200px;
@@ -1209,7 +1210,6 @@
   /* Skeleton */
   .skeleton-card {}
   .skeleton-poster {
-    width: 100%;
     aspect-ratio: 2 / 3;
     border-radius: var(--weeb-radius-lg);
     background: var(--weeb-surface);

--- a/src/svelte/components/SeasonPage.svelte
+++ b/src/svelte/components/SeasonPage.svelte
@@ -800,6 +800,7 @@
     gap: 16px;
     min-height: 400px;
     transition: opacity 0.2s ease;
+    align-items: start;
   }
   .shows-grid.loading {
     opacity: 0.4;


### PR DESCRIPTION
## Summary
- Fix card sizing inconsistencies in Safari by changing grid behavior
- Change `auto-fit` to `auto-fill` to prevent last row from stretching
- Add `align-items: start` to prevent vertical stretching of grid items
- Add `width: 100%` to poster-card for consistent sizing

## Test plan
- [x] Verified cards display with consistent heights in Chrome
- [x] Verified fix works in Safari (user tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)