### PR TITLE
feat: point production CDN at R2 custom domain

### DIFF
--- a/src/config/static/production/index.json
+++ b/src/config/static/production/index.json
@@ -2,7 +2,7 @@
   "api_host": "https://weeb-api.weeb.vip",
   "graphql_host": "https://gateway.weeb.vip/graphql",
   "algolia_index": "anime",
-  "cdn_url": "https://cdn.weeb.vip/weeb",
+  "cdn_url": "https://weeb.cdn.weeb.vip",
   "cdn_user_url": "https://cdn.weeb.vip/weeb-user",
   "posthog_api_key": "phc_MbyMDQJkiLR9NSfSGSpEhA1RSwu79mROuedzQvxgxoI"
 }

--- a/src/pages/show/[id].astro
+++ b/src/pages/show/[id].astro
@@ -146,7 +146,7 @@ try {
       : `Watch and track ${animeTitle} episodes, get notifications, and manage your anime watchlist on WeebVIP.`;
 
     if (anime.imageUrl) {
-      animeImage = `https://cdn.weeb.vip/weeb/${encodeURIComponent(anime.imageUrl)}`;
+      animeImage = `https://weeb.cdn.weeb.vip/${encodeURIComponent(anime.imageUrl)}`;
     }
   }
 

--- a/src/svelte/components/HeroBanner.svelte
+++ b/src/svelte/components/HeroBanner.svelte
@@ -85,7 +85,7 @@
     // Priority 3: CDN poster as fallback
     const posterUrl = GetImageFromAnime(anime);
     if (posterUrl) {
-      sources.push(`https://cdn.weeb.vip/weeb/${encodeURIComponent(posterUrl)}`);
+      sources.push(`https://weeb.cdn.weeb.vip/${encodeURIComponent(posterUrl)}`);
     }
 
     return sources;

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -231,7 +231,7 @@
     // Priority 3: CDN poster as fallback
     const posterUrl = GetImageFromAnime(anime);
     if (posterUrl) {
-      sources.push(`https://cdn.weeb.vip/weeb/${encodeURIComponent(posterUrl)}`);
+      sources.push(`https://weeb.cdn.weeb.vip/${encodeURIComponent(posterUrl)}`);
     }
 
     return sources;

--- a/src/svelte/utils/image.ts
+++ b/src/svelte/utils/image.ts
@@ -12,7 +12,7 @@ export function getCdnUrl(): string {
     return (window as any).global.config.cdn_url;
   }
 
-  return 'https://cdn.weeb.vip/weeb';
+  return 'https://weeb.cdn.weeb.vip';
 }
 
 export function getSafeImageUrl(src: string, path?: string): string {


### PR DESCRIPTION
Updates production image URLs from `https://cdn.weeb.vip/weeb/...` (self-hosted MinIO, bucket in path) to `https://weeb.cdn.weeb.vip/...` (R2 custom domain, objects at root). Companion to weeb-vip/weeb-argocd#2.

Changed:
- `src/config/static/production/index.json` — `cdn_url`
- `src/svelte/utils/image.ts` — hardcoded fallback in `getCdnUrl()`
- `src/pages/show/[id].astro`, `HeroBanner.svelte`, `ShowContent.svelte` — hardcoded poster URL builders

Left unchanged:
- `cdn_user_url` (`weeb-user` bucket — not migrated yet)
- all staging configs

Verified: `https://weeb.cdn.weeb.vip/<object>` serves the migrated images correctly (checked in a real browser; curl gets a Cloudflare bot challenge, which is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)