### PR TITLE
feat: point production user CDN at R2 custom domain

### DIFF
--- a/src/config/static/production/index.json
+++ b/src/config/static/production/index.json
@@ -3,6 +3,6 @@
   "graphql_host": "https://gateway.weeb.vip/graphql",
   "algolia_index": "anime",
   "cdn_url": "https://cdn.weeb.vip/weeb",
-  "cdn_user_url": "https://cdn.weeb.vip/weeb-user",
+  "cdn_user_url": "https://user.cdn.weeb.vip",
   "posthog_api_key": "phc_MbyMDQJkiLR9NSfSGSpEhA1RSwu79mROuedzQvxgxoI"
 }


### PR DESCRIPTION
Updates production `cdn_user_url` from `https://cdn.weeb.vip/weeb-user` to `https://user.cdn.weeb.vip`. Companion to #39.

## ⚠️ Do not merge yet — prerequisites missing

As of opening this PR:
1. **`user.cdn.weeb.vip` does not resolve** — the custom domain hasn't been connected to an R2 bucket in Cloudflare.
2. **The `weeb-user` data is not in R2** — it's still only in MinIO (6 objects / 136 KB, user profile avatars). The existing R2 token is scoped to the `weeb` bucket, so it can't be used to migrate this one.

To unblock: create the `weeb-user` R2 bucket, an API token that can write it, and connect the `user.cdn.weeb.vip` custom domain. The data copy itself takes seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)