### PR TITLE
feat: serve hero banners from CDN with poster fallback

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -166,10 +166,8 @@ let bannerImageUrl = null;
 if (currentlyAiringData?.getAiringAnimeAll?.length > 0) {
   console.log('airing data', currentlyAiringData.getAiringAnimeAll.map(a => ({airTime: a.airtime, title: a.title})));
   const firstAnime = currentlyAiringData.getAiringAnimeAll[0];
-  if (firstAnime.thetvdbid) {
-    bannerImageUrl = `https://weeb-api.staging.weeb.vip/show/anime/series/${firstAnime.thetvdbid}/fanart?w=1920&h=1080&fit=cover&q=85&f=webp`;
-  } else if (firstAnime.anidbid) {
-    bannerImageUrl = `https://weeb-api.staging.weeb.vip/show/anime/anidb/series/${firstAnime.anidbid}/fanart?w=1920&h=1080&fit=cover&q=85&f=webp`;
+  if (firstAnime.id) {
+    bannerImageUrl = `https://cdn.weeb.vip/weeb/banners/${encodeURIComponent(firstAnime.id)}`;
   }
 }
 

--- a/src/svelte/components/HeroBanner.svelte
+++ b/src/svelte/components/HeroBanner.svelte
@@ -59,30 +59,12 @@
   function generateImageSources(): string[] {
     const sources: string[] = [];
 
-    const baseParams = new URLSearchParams({
-      w: '1920',  // Max width for hero banners
-      h: '1080',  // Max height for hero banners
-      fit: 'cover',
-      q: '85'     // High quality for hero images
-    });
-
-    if (supportsWebP) {
-      baseParams.set('f', 'webp');
+    // Priority 1: CDN banner (tvdb artwork synced by thetvdb-enrichment)
+    if (anime.id) {
+      sources.push(`https://cdn.weeb.vip/weeb/banners/${encodeURIComponent(anime.id)}`);
     }
 
-    // Priority 1: TVDB fanart (highest quality)
-    if (anime.thetvdbid) {
-      const baseUrl = `https://weeb-api.staging.weeb.vip/show/anime/series/${anime.thetvdbid}/fanart`;
-      sources.push(`${baseUrl}?${baseParams.toString()}`);
-    }
-
-    // Priority 2: AniDB fanart
-    if (anime.anidbid) {
-      const baseUrl = `https://weeb-api.staging.weeb.vip/show/anime/anidb/series/${anime.anidbid}/fanart`;
-      sources.push(`${baseUrl}?${baseParams.toString()}`);
-    }
-
-    // Priority 3: CDN poster as fallback
+    // Priority 2: CDN poster as fallback
     const posterUrl = GetImageFromAnime(anime);
     if (posterUrl) {
       sources.push(`https://cdn.weeb.vip/weeb/${encodeURIComponent(posterUrl)}`);

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -205,30 +205,12 @@
 
     const sources: string[] = [];
 
-    const baseParams = new URLSearchParams({
-      w: '1920',
-      h: '1080',
-      fit: 'cover',
-      q: '85'
-    });
-
-    if (supportsWebP) {
-      baseParams.set('f', 'webp');
+    // Priority 1: CDN banner (tvdb artwork synced by thetvdb-enrichment)
+    if (anime.id) {
+      sources.push(`https://cdn.weeb.vip/weeb/banners/${encodeURIComponent(anime.id)}`);
     }
 
-    // Priority 1: TVDB fanart (highest quality)
-    if (anime.thetvdbid) {
-      const baseUrl = `https://weeb-api.staging.weeb.vip/show/anime/series/${anime.thetvdbid}/fanart`;
-      sources.push(`${baseUrl}?${baseParams.toString()}`);
-    }
-
-    // Priority 2: AniDB fanart
-    if (anime.anidbid) {
-      const baseUrl = `https://weeb-api.staging.weeb.vip/show/anime/anidb/series/${anime.anidbid}/fanart`;
-      sources.push(`${baseUrl}?${baseParams.toString()}`);
-    }
-
-    // Priority 3: CDN poster as fallback
+    // Priority 2: CDN poster as fallback
     const posterUrl = GetImageFromAnime(anime);
     if (posterUrl) {
       sources.push(`https://cdn.weeb.vip/weeb/${encodeURIComponent(posterUrl)}`);


### PR DESCRIPTION
Part 3 of moving hero banners off the live weeb-api fanart proxy (weeb-vip/image-sync#4, weeb-vip/thetvdb-enrichment#2).

- `HeroBanner.svelte`, `ShowContent.svelte`, `index.astro` (SSR preload): banner source is now `cdn.weeb.vip/weeb/banners/<anime-id>` — static object on the CDN, no runtime service dependency
- **Poster fallback kept**: the existing source-cascade falls back to `cdn.weeb.vip/weeb/<poster>` when no banner object exists (the `onerror` cascade already handles 404s)
- Removes all `weeb-api.staging.weeb.vip` fanart references from production code (they were dead anyway — that host's cert expired in the cert-manager outage). The resize params were dropped since the old endpoint ignored them.

Note: banners appear per-anime as thetvdb-enrichment reprocesses records; until then the poster fallback shows. A backfill (replaying the enrichment topic) can populate them in bulk.

Merge order: image-sync#4 → thetvdb-enrichment#2 → this (frontend degrades gracefully to posters regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)