### PR TITLE
feat: staging CDN moves to staging.cdn.weeb.vip

### DIFF
--- a/src/config/static/staging/index.json
+++ b/src/config/static/staging/index.json
@@ -2,6 +2,6 @@
   "api_host": "https://weeb-api.staging.weeb.vip",
   "graphql_host": "https://gateway.staging.weeb.vip/graphql",
   "algolia_index": "anime-staging",
-  "cdn_url": "https://cdn.weeb.vip/weeb-staging",
+  "cdn_url": "https://staging.cdn.weeb.vip/weeb-staging",
   "cdn_user_url": "https://cdn.weeb.vip/weeb-user-staging"
 }


### PR DESCRIPTION
Companion to weeb-vip/weeb-argocd#9 — staging `cdn_url` becomes `https://staging.cdn.weeb.vip/weeb-staging`. Requires the `staging.cdn.weeb.vip` custom domain on the R2 `weeb` bucket. `cdn_user_url` and dev/local configs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)