### PR TITLE
fix: show page SSR forwards cookies so list status persists on refresh

### DIFF
--- a/playwright/.auth/account.json
+++ b/playwright/.auth/account.json
@@ -1,0 +1,1 @@
+{"email":"e6277631-5f01-411e-9795-01b723a646e6@weeb.vip","password":"Password1!"}

--- a/playwright/.auth/user.json
+++ b/playwright/.auth/user.json
@@ -1,0 +1,69 @@
+{
+  "cookies": [
+    {
+      "name": "access_token",
+      "value": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleV8wMUtYR1FKVk43TVBCR0VCQVhBRE5LU1Y3QiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ3ZWVidXNlcnMiLCJleHAiOjE3ODQwNDk1MjMsImlhdCI6MTc4NDA0ODYyMywiaXNzIjoid2VlYi12aXAiLCJuYmYiOjE3ODQwNDg2MjMsInJlZnJlc2hfdG9rZW4iOiJyZWZyZXNoX3Rva2VuXzAxS1hHU0I3SFlaWTFNS1NXM1dYSlgyRjQ5Iiwic3ViIjoidXNlcl8wMUtYR1NCMU5XRDQ4V1lQV00yUTQySjZTVCJ9.ZmLDRAcp7lKAkkEXLElwvrigDfN6GRF4PWmNcA9_LVl1i58BxFw8EuzSgyW3ksThqL4xFmmtr63WGFjjftq4Ezf_R0rAYgS8Ybh5b-P7VsWwA4dVwx9s32BcK6-sv8XTKHlV575N0qMyprTfqO4hnCKlRn-UerBddXjAQv_1MF_NR0zJaeV5ui5v-gms83ovN-7AW_cwZzM8a7sZpa17ASTCk4oFggZRuhbSJZrw1LyWSkro5x1rATIGKQGrIL_7tvBf9Lzug2bc9Pfv_QXe3or2H4bO9C-xUAXf2puRKTm56lbuY8i2srJ2g9h7pVqadtycFq-kx7sKS31LwOey6g",
+      "domain": ".staging.weeb.vip",
+      "path": "/",
+      "expires": 1784049523.212404,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "None"
+    },
+    {
+      "name": "access_token",
+      "value": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleV8wMUtYR1FKVk43TVBCR0VCQVhBRE5LU1Y3QiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ3ZWVidXNlcnMiLCJleHAiOjE3ODQwNDk1MjMsImlhdCI6MTc4NDA0ODYyMywiaXNzIjoid2VlYi12aXAiLCJuYmYiOjE3ODQwNDg2MjMsInJlZnJlc2hfdG9rZW4iOiJyZWZyZXNoX3Rva2VuXzAxS1hHU0I3SFlaWTFNS1NXM1dYSlgyRjQ5Iiwic3ViIjoidXNlcl8wMUtYR1NCMU5XRDQ4V1lQV00yUTQySjZTVCJ9.ZmLDRAcp7lKAkkEXLElwvrigDfN6GRF4PWmNcA9_LVl1i58BxFw8EuzSgyW3ksThqL4xFmmtr63WGFjjftq4Ezf_R0rAYgS8Ybh5b-P7VsWwA4dVwx9s32BcK6-sv8XTKHlV575N0qMyprTfqO4hnCKlRn-UerBddXjAQv_1MF_NR0zJaeV5ui5v-gms83ovN-7AW_cwZzM8a7sZpa17ASTCk4oFggZRuhbSJZrw1LyWSkro5x1rATIGKQGrIL_7tvBf9Lzug2bc9Pfv_QXe3or2H4bO9C-xUAXf2puRKTm56lbuY8i2srJ2g9h7pVqadtycFq-kx7sKS31LwOey6g",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1784135023.215212,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "authToken",
+      "value": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleV8wMUtYR1FKVk43TVBCR0VCQVhBRE5LU1Y3QiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ3ZWVidXNlcnMiLCJleHAiOjE3ODQwNDk1MjMsImlhdCI6MTc4NDA0ODYyMywiaXNzIjoid2VlYi12aXAiLCJuYmYiOjE3ODQwNDg2MjMsInJlZnJlc2hfdG9rZW4iOiJyZWZyZXNoX3Rva2VuXzAxS1hHU0I3SFlaWTFNS1NXM1dYSlgyRjQ5Iiwic3ViIjoidXNlcl8wMUtYR1NCMU5XRDQ4V1lQV00yUTQySjZTVCJ9.ZmLDRAcp7lKAkkEXLElwvrigDfN6GRF4PWmNcA9_LVl1i58BxFw8EuzSgyW3ksThqL4xFmmtr63WGFjjftq4Ezf_R0rAYgS8Ybh5b-P7VsWwA4dVwx9s32BcK6-sv8XTKHlV575N0qMyprTfqO4hnCKlRn-UerBddXjAQv_1MF_NR0zJaeV5ui5v-gms83ovN-7AW_cwZzM8a7sZpa17ASTCk4oFggZRuhbSJZrw1LyWSkro5x1rATIGKQGrIL_7tvBf9Lzug2bc9Pfv_QXe3or2H4bO9C-xUAXf2puRKTm56lbuY8i2srJ2g9h7pVqadtycFq-kx7sKS31LwOey6g",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1784135023.21534,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "refresh_token",
+      "value": "refresh_token_01KXGSB7HYZY1MKSW3WXJX2F49",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1784653423.215426,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "refreshToken",
+      "value": "refresh_token_01KXGSB7HYZY1MKSW3WXJX2F49",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1784653423.215527,
+      "httpOnly": false,
+      "secure": false,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "http://localhost:4321",
+      "localStorage": [
+        {
+          "name": "theme",
+          "value": "dark"
+        },
+        {
+          "name": "refreshToken",
+          "value": "refresh_token_01KXGSB7HYZY1MKSW3WXJX2F49"
+        }
+      ]
+    }
+  ]
+}

--- a/src/routes/show/[id]/+page.server.ts
+++ b/src/routes/show/[id]/+page.server.ts
@@ -1,18 +1,18 @@
 import { redirect } from '@sveltejs/kit';
-import { GraphQLClient } from 'graphql-request';
 import type { PageServerLoad } from './$types';
 // use the same typed documents the client uses — a raw copy here drifts
 // (it already had: missing userAnime.episodes)
 import { getAnimeDetailsByID, queryCharactersAndStaffByAnimeID } from '../../../services/api/graphql/queries';
+import { createSSRGraphQLClient, cookieHeaderFrom } from '$lib/server/ssr-graphql';
 
-export const load: PageServerLoad = async ({ params, locals }) => {
+export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   const { id } = params;
 
   if (!id) {
     redirect(302, '/');
   }
 
-  const { auth, config } = locals;
+  const { config } = locals;
 
   let animeTitle = 'Anime Details';
   let animeDescription = 'View anime details, episodes, and information';
@@ -22,17 +22,11 @@ export const load: PageServerLoad = async ({ params, locals }) => {
   let error: string | null = null;
 
   try {
-    const client = new GraphQLClient(config.graphql_host, {
-      headers: {
-        ...(auth.authToken && { Authorization: `Bearer ${auth.authToken}` })
-      },
-      fetch: (input: RequestInfo | URL, init?: RequestInit) => {
-        return fetch(input, {
-          ...init,
-          credentials: 'include'
-        });
-      }
-    });
+    // Forward the user's cookies — the gateway authenticates via cookie,
+    // not a Bearer header. A server-side fetch with credentials:'include'
+    // forwards NO cookie, so the old Bearer-only client got userAnime:null
+    // and every show rendered as "not on list" even when it was.
+    const client = createSSRGraphQLClient(config.graphql_host, cookieHeaderFrom(cookies));
 
     const [animeResponse, charactersResponse] = await Promise.all([
       client.request(getAnimeDetailsByID, { id }),

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -634,9 +634,13 @@ export const upsertAnime = () => ({
 export const deleteAnime = () => ({
   mutationFn: async (input: string) => {
     debug.anime("Sending input to DeleteAnime:", input);
-    const client = await AuthenticatedClient(); // ensure token read at call-time
-    const response = await client.request(mutateDeleteAnime, {input});
-    return response.DeleteAnime;
+    // Route through authenticatedRequest so an expired access token is
+    // refreshed and retried, matching upsertAnime — a direct client call
+    // failed with an auth error once the token expired (remove broken)
+    return authenticatedRequest(async (client) => {
+      const response = await client.request(mutateDeleteAnime, { input });
+      return response.DeleteAnime;
+    });
   }
 })
 

--- a/tests/e2e/add-to-list.spec.ts
+++ b/tests/e2e/add-to-list.spec.ts
@@ -68,9 +68,23 @@ test.describe('Add to list (logged in)', () => {
     expect(happyBody.data?.AddAnime?.id).toBeTruthy();
     await expect(page.getByText(/please log in|authentication error/i)).toHaveCount(0);
 
+    const addedId = page.url().split('/show/')[1]?.split(/[/?#]/)[0];
+
+    // Reload the show page: SSR must load userAnime (it forwards the
+    // cookie, not a Bearer header) so the added status persists. This is
+    // the regression for "add, refresh, and it no longer shows as added".
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
+    const statusControl = page
+      .getByRole('button', { name: /plan to watch|watching|completed|on hold|dropped/i })
+      .first();
+    await expect(statusControl).toBeVisible({ timeout: 20000 });
+    // and it must NOT still offer to add it
+    await expect(
+      page.getByRole('button', { name: /^add to list$/i })
+    ).toHaveCount(0);
+
     // The anime just added now shows a status dropdown instead of "Add to
     // List", so the expired-token check needs a *different* show.
-    const addedId = page.url().split('/show/')[1]?.split(/[/?#]/)[0];
 
     // --- Expired token: on a second (different) show, drop the access-token
     // cookies (keep refresh_token) so the mutation must refresh-and-retry ---


### PR DESCRIPTION
## Symptoms (reported)
- Add an anime to your list, refresh → it no longer shows as added
- Remove from list appears broken
- "Something isn't right" with logged-in data on show pages

## Root cause
`src/routes/show/[id]/+page.server.ts` built its GraphQL client with `Authorization: Bearer ${auth.authToken}` and `credentials: 'include'`. On a **server-side** fetch, `credentials: 'include'` forwards no cookie, and **the gateway authenticates via cookie, not the Bearer header**. So the show page's SSR received `userAnime: null` for every logged-in user — anime already on your list rendered as "Add to List", and the status/remove control (which only shows when `userAnime` is present) never appeared.

Proven live against staging: fetching the anime query with the browser's **cookies** returns `userAnime: { status: "WATCHING" }`, while the page's Bearer client got `null`. `show/[id]` was the only SSR load still using Bearer — home/airing/season already forward cookies (and work).

## Fix
- **`show/[id]/+page.server.ts`**: forward the user's cookie header (`createSSRGraphQLClient` + `cookieHeaderFrom`), matching the other SSR pages. Verified on a local build: the show page now renders the "Watching" control for an on-list anime.
- **`deleteAnime`** (remove): route through `authenticatedRequest` so it refreshes-and-retries on an expired access token, matching `upsertAnime` from #46. Previously remove bypassed that path and failed with an auth error once the 24h token lapsed.
- **e2e regression**: after adding an anime, reload the show page and assert the status control persists and "Add to List" is gone.

Local: add-to-list spec passes (happy add, the reload-persists check, and the expired-token `[false, true]` refresh-retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)