### PR TITLE
fix: episode notifications only fire once per anime (dedup key omits episode #)

### DIFF
--- a/src/workers/animeNotifications.worker.ts
+++ b/src/workers/animeNotifications.worker.ts
@@ -403,7 +403,7 @@ function checkNotifications() {
 
     // Check if currently airing
     if (isCurrentlyAiring(nextEpisode.airDate, anime.broadcast, durationMinutes)) {
-      const notificationKey = `${anime.id}-airing`;
+      const notificationKey = `${anime.id}-${nextEpisode.episodeNumber ?? 'x'}-airing`;
       if (!notifiedAnime.has(notificationKey)) {
         notifiedAnime.add(notificationKey);
         postMessage({
@@ -423,7 +423,7 @@ function checkNotifications() {
     // Check if finished airing (within the last 30 minutes)
     const finishedTime = timeToAir + episodeDurationMs;
     if (finishedTime < 0 && finishedTime > -(30 * 60 * 1000)) {
-      const notificationKey = `${anime.id}-finished`;
+      const notificationKey = `${anime.id}-${nextEpisode.episodeNumber ?? 'x'}-finished`;
       if (!notifiedAnime.has(notificationKey)) {
         notifiedAnime.add(notificationKey);
         postMessage({
@@ -443,7 +443,7 @@ function checkNotifications() {
     // Check for 30-minute "airing soon" notification (within 5-second window)
     const airingSoonTime = timeToAir - (30 * 60 * 1000);
     if (airingSoonTime >= 0 && airingSoonTime < 5000) {
-      const notificationKey = `${anime.id}-airing-soon`;
+      const notificationKey = `${anime.id}-${nextEpisode.episodeNumber ?? 'x'}-airing-soon`;
       if (!notifiedAnime.has(notificationKey)) {
         notifiedAnime.add(notificationKey);
         postMessage({
@@ -462,7 +462,7 @@ function checkNotifications() {
     // Check for 5-minute warning (within 5-second window)
     const fiveMinuteWarning = timeToAir - (5 * 60 * 1000);
     if (fiveMinuteWarning >= 0 && fiveMinuteWarning < 5000) {
-      const notificationKey = `${anime.id}-warning`;
+      const notificationKey = `${anime.id}-${nextEpisode.episodeNumber ?? 'x'}-warning`;
       if (!notifiedAnime.has(notificationKey)) {
         notifiedAnime.add(notificationKey);
         postMessage({
@@ -480,7 +480,7 @@ function checkNotifications() {
 
     // Check for airing notification (within 5-second window)
     if (timeToAir >= 0 && timeToAir < 5000) {
-      const notificationKey = `${anime.id}-airing`;
+      const notificationKey = `${anime.id}-${nextEpisode.episodeNumber ?? 'x'}-airing`;
       if (!notifiedAnime.has(notificationKey)) {
         notifiedAnime.add(notificationKey);
         postMessage({
@@ -619,7 +619,3 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
   }
 });
 
-// Handle worker termination
-self.addEventListener('beforeunload', () => {
-  clearAllIntervals();
-});


### PR DESCRIPTION
## Bug
The notifications worker deduped with keys like `${anime.id}-airing` / `-warning` / `-finished` / `-airing-soon`. Once episode N of an anime fired a notification, that key stayed in the `notifiedAnime` set for the rest of the session, so **episode N+1 (and every later episode) of that anime never notified**. Because SvelteKit doesn't reload between navigations, a browsing session is long-lived, so this bites any regularly-airing show you follow.

## Fix
Include the episode number in every dedup key (`${anime.id}-${episodeNumber}-airing`, etc.), so each episode is tracked independently — matching what the main-thread `NotificationTracker` already does.

Also removed the dead `beforeunload` listener (Web Workers never receive that event; interval cleanup already happens via the `stop` message).

Build + the worker unit test + all 82 tests pass.

Follow-up (noted, not in this PR): the worker still copies ~250 lines of `airTimeUtils` verbatim — those can be imported from the shared module (they're currently identical), but that's a refactor better kept separate from this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)