### PR TITLE
fix: clear auth cookies on a definitively-failed token refresh

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { redirect, type Handle } from '@sveltejs/kit';
 import { getConfig } from './config/build-time-loader';
 import { AuthStorage } from './utils/auth-storage';
 import { refreshTokenSSR, isTokenExpired } from './utils/ssr-token-refresh';
+import { clearAuthCookies } from '$lib/server/auth-cookies';
 
 // Config cache for performance
 let configData: any = null;
@@ -61,33 +62,27 @@ export const handle: Handle = async ({ event, resolve }) => {
   const hasRefreshToken = !!authResult.tokens.refreshToken;
   const cookieShim = astroStyleCookies(cookies);
 
-  if (hasRefreshToken) {
-    if (!hasAccessToken) {
-      // CASE 1: Has refresh token but NO access token - refresh immediately
-      const refreshResult = await refreshTokenSSR(cookieShim, configData?.graphql_host || 'http://localhost:8079');
+  // Refresh when there's a refresh token and the access token is missing or
+  // expired. On a definitive failure (revoked/expired refresh token) clear
+  // the auth cookies so we don't blocking-retry a doomed refresh on every
+  // subsequent request; leave them on a transient (network/5xx) failure.
+  const needsRefresh = hasRefreshToken &&
+    (!hasAccessToken || (authResult.tokens.authToken && isTokenExpired(authResult.tokens.authToken)));
 
-      if (refreshResult.success) {
-        authResult.tokens.authToken = refreshResult.authToken;
-        authResult.tokens.refreshToken = refreshResult.refreshToken || authResult.tokens.refreshToken;
-        authResult.isLoggedIn = true;
-      } else {
-        console.error('[Hooks] ❌ Token refresh failed:', refreshResult.error);
-        authResult.isLoggedIn = false;
-      }
-    } else if (authResult.tokens.authToken && isTokenExpired(authResult.tokens.authToken)) {
-      // CASE 2: Has access token but it's EXPIRED - refresh it
-      const refreshResult = await refreshTokenSSR(cookieShim, configData?.graphql_host || 'http://localhost:8079');
+  if (needsRefresh) {
+    const refreshResult = await refreshTokenSSR(cookieShim, configData?.graphql_host || 'http://localhost:8079');
 
-      if (refreshResult.success) {
-        authResult.tokens.authToken = refreshResult.authToken;
-        authResult.tokens.refreshToken = refreshResult.refreshToken || authResult.tokens.refreshToken;
-        authResult.isLoggedIn = true;
-      } else {
-        console.error('[Hooks] ❌ Token refresh failed:', refreshResult.error);
-        authResult.isLoggedIn = false;
+    if (refreshResult.success) {
+      authResult.tokens.authToken = refreshResult.authToken;
+      authResult.tokens.refreshToken = refreshResult.refreshToken || authResult.tokens.refreshToken;
+      authResult.isLoggedIn = true;
+    } else {
+      console.error('[Hooks] ❌ Token refresh failed:', refreshResult.error);
+      authResult.isLoggedIn = false;
+      if (refreshResult.authError) {
+        clearAuthCookies(cookies);
       }
     }
-    // CASE 3: valid access token - continue normal flow
   } else if (hasAccessToken && authResult.tokens.authToken && isTokenExpired(authResult.tokens.authToken)) {
     // Access token expired and no refresh token available
     authResult.isLoggedIn = false;

--- a/src/utils/ssr-token-refresh.ts
+++ b/src/utils/ssr-token-refresh.ts
@@ -12,6 +12,10 @@ interface RefreshTokenResponse {
   authToken?: string;
   refreshToken?: string;
   error?: string;
+  // true when the refresh token is definitively invalid (revoked/expired)
+  // vs a transient failure (network / 5xx) — lets the caller clear the
+  // cookies instead of retrying a doomed refresh on every request
+  authError?: boolean;
 }
 
 /**
@@ -60,7 +64,8 @@ export async function refreshTokenSSR(
       debug.error('[SSR] Token refresh HTTP error:', response.status);
       return {
         success: false,
-        error: `HTTP error: ${response.status}`
+        error: `HTTP error: ${response.status}`,
+        authError: response.status === 401 || response.status === 403
       };
     }
 
@@ -70,7 +75,8 @@ export async function refreshTokenSSR(
       debug.error('[SSR] Token refresh GraphQL errors:', data.errors);
       return {
         success: false,
-        error: data.errors[0]?.message || 'GraphQL error'
+        error: data.errors[0]?.message || 'GraphQL error',
+        authError: true
       };
     }
 


### PR DESCRIPTION
## Problem
When a user's refresh token is revoked or expired, `hooks.server.ts` set `isLoggedIn = false` but **left the `refresh_token` cookie in place**. So every subsequent request re-entered the refresh path, performed a **blocking round-trip to the gateway that was guaranteed to fail**, and only then rendered — added latency to every page view and needless load on the auth service, indefinitely.

## Fix
- `refreshTokenSSR` now returns `authError: true` for **definitive** failures (the refresh mutation returned a GraphQL error, or HTTP 401/403) and leaves it unset for **transient** ones (network error / 5xx).
- Hooks clears the auth cookies (via the shared `clearAuthCookies()`) **only on a definitive failure**, so the doomed refresh isn't retried every request. A transient failure leaves the cookies so a later request can still recover.
- Collapsed the duplicated `CASE 1` / `CASE 2` refresh blocks into a single path.

Build + 82 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)