### PR TITLE
fix(a11y): trap focus within Modal and restore it on close

### DIFF
--- a/src/svelte/components/Modal.svelte
+++ b/src/svelte/components/Modal.svelte
@@ -51,14 +51,65 @@
       }
     };
   }
+
+  const FOCUSABLE = [
+    'a[href]', 'button:not([disabled])', 'input:not([disabled])',
+    'select:not([disabled])', 'textarea:not([disabled])', '[tabindex]:not([tabindex="-1"])'
+  ].join(',');
+
+  function focusable(node: HTMLElement): HTMLElement[] {
+    return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE))
+      .filter((el) => el.offsetParent !== null || el === document.activeElement);
+  }
+
+  // Trap Tab focus within the modal, move focus in on open, and restore it on
+  // close so keyboard users can't tab into the (inert) page behind the dialog.
+  function trapFocus(node: HTMLElement) {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Focus the first focusable element, falling back to the dialog itself.
+    const initial = focusable(node)[0] ?? node;
+    // tick() isn't needed: the node is already in the DOM when the action runs.
+    initial.focus();
+
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const items = focusable(node);
+      if (items.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !node.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    node.addEventListener('keydown', onKeydown);
+
+    return {
+      destroy() {
+        node.removeEventListener('keydown', onKeydown);
+        // Restore focus to whatever opened the modal.
+        previouslyFocused?.focus?.();
+      }
+    };
+  }
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
 
 {#if isOpen && mounted}
-  <div use:portal class="weeb-modal-backdrop" on:click={handleBackdropClick} role="dialog" aria-modal="true">
+  <div use:portal class="weeb-modal-backdrop" on:click={handleBackdropClick} role="dialog" aria-modal="true" aria-label="Dialog">
     <div class="weeb-modal-container">
-      <div class="weeb-modal-card {className}" on:click|stopPropagation>
+      <div class="weeb-modal-card {className}" use:trapFocus tabindex="-1" on:click|stopPropagation>
         {#if showCloseButton}
           <button type="button" class="weeb-modal-close" on:click={closeModal} aria-label="Close modal">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/svelte/components/Modal.svelte
+++ b/src/svelte/components/Modal.svelte
@@ -67,10 +67,14 @@
   function trapFocus(node: HTMLElement) {
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
-    // Focus the first focusable element, falling back to the dialog itself.
-    const initial = focusable(node)[0] ?? node;
-    // tick() isn't needed: the node is already in the DOM when the action runs.
-    initial.focus();
+    // Defer initial focus to the next frame. The `portal` action on the parent
+    // backdrop runs *after* this one (children mount first) and appendChild's
+    // the subtree to <body> — moving a node blurs whatever we focused, kicking
+    // focus back to <body>. Focusing after the move lands is what makes it stick.
+    const raf = requestAnimationFrame(() => {
+      const initial = focusable(node)[0] ?? node;
+      initial.focus();
+    });
 
     function onKeydown(e: KeyboardEvent) {
       if (e.key !== 'Tab') return;
@@ -96,6 +100,7 @@
 
     return {
       destroy() {
+        cancelAnimationFrame(raf);
         node.removeEventListener('keydown', onKeydown);
         // Restore focus to whatever opened the modal.
         previouslyFocused?.focus?.();

--- a/tests/e2e/a11y-modal.spec.ts
+++ b/tests/e2e/a11y-modal.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+import { waitForHomepage } from './helpers';
+
+// Whether the currently-focused element lives inside the open dialog. The modal
+// is portaled to <body>, so we check containment against the [role="dialog"]
+// node rather than any component boundary.
+const focusInDialog = (page: Page) =>
+  page.evaluate(() => {
+    const d = document.querySelector('[role="dialog"]');
+    return !!d && !!document.activeElement && d.contains(document.activeElement);
+  });
+
+// Opens the auth modal via the header (desktop) or drawer (mobile). Mode
+// (login vs register) is irrelevant to focus behaviour, so we don't force it.
+async function openAuthModal(page: Page): Promise<{ dialog: Locator; isMobile: boolean }> {
+  const dialog = page.getByRole('dialog');
+  const mobileMenu = page.getByRole('button', { name: 'Open menu' });
+  const isMobile = await mobileMenu.isVisible().catch(() => false);
+
+  if (isMobile) {
+    await mobileMenu.click();
+    const drawerRegister = page.getByRole('button', { name: 'Register', exact: true });
+    await drawerRegister.waitFor({ state: 'visible', timeout: 5000 });
+    await drawerRegister.click();
+  } else {
+    await page.locator('nav').getByRole('button', { name: 'Register', exact: true }).click();
+  }
+
+  await dialog.waitFor({ state: 'visible', timeout: 10000 });
+  return { dialog, isMobile };
+}
+
+test.describe('Modal focus trap (a11y)', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+  });
+
+  test('moves focus into the dialog on open', async ({ page }) => {
+    await openAuthModal(page);
+    await expect.poll(() => focusInDialog(page), {
+      message: 'focus should move into the dialog when it opens',
+    }).toBe(true);
+  });
+
+  test('keeps Tab focus inside the dialog (forward and backward)', async ({ page }) => {
+    await openAuthModal(page);
+    await expect.poll(() => focusInDialog(page)).toBe(true);
+
+    // More presses than the dialog has focusable elements, so a missing trap
+    // would tab out into the (inert) page behind the modal and fail here.
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('Tab');
+      expect(await focusInDialog(page), `focus escaped the dialog after ${i + 1} Tab press(es)`).toBe(true);
+    }
+
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('Shift+Tab');
+      expect(await focusInDialog(page), `focus escaped the dialog after ${i + 1} Shift+Tab press(es)`).toBe(true);
+    }
+  });
+
+  test('closes on Escape and restores focus to the trigger', async ({ page }) => {
+    const mobileMenu = page.getByRole('button', { name: 'Open menu' });
+    const isMobile = await mobileMenu.isVisible().catch(() => false);
+    // The mobile drawer trigger unmounts when the drawer closes, so there is no
+    // stable element to restore focus to; the restore contract only applies to
+    // a persistent trigger.
+    test.skip(isMobile, 'mobile opens via a drawer whose trigger unmounts');
+
+    const trigger = page.locator('nav').getByRole('button', { name: 'Register', exact: true });
+    // Drive it by keyboard: clicking a button does not focus it in Firefox/WebKit,
+    // which would make "restore to trigger" untestable. This is also the real
+    // keyboard-user journey the restore behaviour exists for.
+    await trigger.focus();
+    await expect(trigger).toBeFocused();
+    await trigger.press('Enter');
+
+    const dialog = page.getByRole('dialog');
+    await dialog.waitFor({ state: 'visible', timeout: 10000 });
+    await expect.poll(() => focusInDialog(page)).toBe(true);
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden({ timeout: 5000 });
+    await expect(trigger).toBeFocused({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## What
The shared `Modal` component (login/register flow, profile image upload, and every other modal consumer) declared `role="dialog"` + `aria-modal="true"` but **never managed focus**:

- Keyboard users could `Tab` straight out of the open dialog into the inert page behind it.
- Focus was silently lost when the dialog closed (never returned to the trigger).

## Change
Adds a `trapFocus` action on the modal card that:
- **Moves focus in** on open (first focusable element, falling back to the card via `tabindex="-1"`).
- **Cycles `Tab`/`Shift+Tab`** within the dialog instead of escaping to the background.
- **Restores focus** to whatever opened the modal on close.
- Gives the dialog an `aria-label`.

Escape-to-close and backdrop-close already existed and are untouched.

### Subtle bug the e2e test caught
Initial focus first landed on `<body>`, not the dialog: the `portal` action `appendChild`'s the backdrop to `<body>` **after** `trapFocus` runs (child actions mount before parent actions), and moving a DOM node blurs whatever was focused. Fixed by deferring initial focus one frame so it lands after the portal move settles.

## Tests
New `tests/e2e/a11y-modal.spec.ts` asserts the actual a11y contract:
1. Focus moves into the dialog on open
2. `Tab` × 12 and `Shift+Tab` × 12 never escape the dialog (trap holds)
3. `Escape` closes and restores focus to the trigger (keyboard-driven, so it's stable on Firefox/WebKit where clicking doesn't focus buttons)

Passing locally on **chromium and firefox**. `svelte-check`: zero new errors; 82/82 unit tests pass.

## Scope note
The other a11y item — keyboard arrow-navigation of the search autocomplete — is a separate follow-up: `AutocompleteAdvanced` has intricate blur/animation/backdrop timing, so it needs its own live validation and test.

> Also carries the merged-but-unreleased `refactor(worker)` air-time dedup to production (first `fix:` release since that landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)