### PR TITLE
fix(a11y): keyboard-navigable search autocomplete (arrow keys, Enter, ARIA combobox)

### DIFF
--- a/src/svelte/components/AutocompleteAdvanced.svelte
+++ b/src/svelte/components/AutocompleteAdvanced.svelte
@@ -26,6 +26,25 @@
   let mobilePanelRef: HTMLDivElement;
   let resultsListRefs: HTMLElement[] = [];
 
+  // Keyboard navigation: the currently highlighted result (-1 = none). The
+  // panel is rendered twice (mobile + desktop) but only one is visible, so a
+  // single flat index drives both; per-device option ids keep the DOM valid.
+  let activeIndex = -1;
+  $: flatItems = (autocompleteState.collections || [])
+    .flatMap((c: any) => filterValidItems(c.items || []));
+  // Keep the highlight in range as results change under the user.
+  $: if (activeIndex >= flatItems.length) activeIndex = flatItems.length - 1;
+
+  function activeDevice(): 'desktop' | 'mobile' {
+    return typeof window !== 'undefined' && window.innerWidth >= 640 ? 'desktop' : 'mobile';
+  }
+
+  function scrollActiveIntoView() {
+    if (activeIndex < 0 || typeof document === 'undefined') return;
+    const el = document.getElementById(`ac-opt-${activeDevice()}-${activeIndex}`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }
+
 
   onMount(async () => {
     // Only run on client-side
@@ -265,6 +284,7 @@
     // Delay to allow click events to fire and animation to complete
     setTimeout(() => {
       isFocused = false;
+      activeIndex = -1;
       if (autocompleteInstance) {
         autocompleteInstance.setIsOpen(false);
       }
@@ -273,6 +293,43 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    const len = flatItems.length;
+
+    if (event.key === 'ArrowDown') {
+      if (!autocompleteState.isOpen) return;
+      event.preventDefault();
+      activeIndex = len === 0 ? -1 : (activeIndex + 1) % len;
+      scrollActiveIntoView();
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      if (!autocompleteState.isOpen) return;
+      event.preventDefault();
+      activeIndex = len === 0 ? -1 : (activeIndex <= 0 ? len - 1 : activeIndex - 1);
+      scrollActiveIntoView();
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      // A highlighted result wins; otherwise fall through to a full search.
+      if (activeIndex >= 0 && flatItems[activeIndex]) {
+        event.preventDefault();
+        handleItemClick(flatItems[activeIndex]);
+      } else if (autocompleteState.query) {
+        event.preventDefault();
+        const query = autocompleteState.query;
+        analytics.searchPerformed(query.trim(), flatItems.length);
+        if (autocompleteInstance) {
+          autocompleteInstance.setIsOpen(false);
+          autocompleteInstance.setQuery('');
+        }
+        (event.target as HTMLInputElement).blur();
+        goto(`/search?query=${encodeURIComponent(query)}`);
+      }
+      return;
+    }
+
     if (event.key === 'Escape') {
       // Animate panel closing on escape
       const panel = window.innerWidth >= 640 ? desktopPanelRef : mobilePanelRef;
@@ -283,6 +340,7 @@
         );
       }
 
+      activeIndex = -1;
       setTimeout(() => {
         isFocused = false;
         if (autocompleteInstance) {
@@ -296,7 +354,9 @@
 
   function handleInputChange(event: Event) {
     const value = (event.target as HTMLInputElement).value;
-    console.log('Input changed:', value);
+    // Results are about to change; drop the highlight so it can't point at a
+    // stale row (Enter would otherwise open the wrong show).
+    activeIndex = -1;
     if (autocompleteInstance) {
       console.log('Setting query on autocomplete instance');
       autocompleteInstance.setQuery(value);
@@ -449,6 +509,11 @@
         on:keydown={handleKeyDown}
         on:input={handleInputChange}
         {...inputProps}
+        role="combobox"
+        aria-expanded={isFocused && autocompleteState.isOpen && flatItems.length > 0}
+        aria-controls="ac-listbox-mobile"
+        aria-autocomplete="list"
+        aria-activedescendant={activeIndex >= 0 ? `ac-opt-mobile-${activeIndex}` : undefined}
       />
       {#if !isFocused}
         <span class="ac-kbd">/</span>
@@ -460,22 +525,25 @@
           style="transform-origin: center top;"
         >
           <div class="ac-panel-divider"></div>
-          {#each autocompleteState.collections as collection}
-            {#if filterValidItems(collection.items).length > 0}
-              <ul class="ac-results-list">
-                {#each filterValidItems(collection.items) as item (item.objectID)}
-                  <AutocompleteItem {item} onClick={() => handleItemClick(item)} />
-                {/each}
-              </ul>
-            {:else if autocompleteState.query}
-              <div class="ac-empty">
-                <svg class="ac-empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
-                <span>No results for '{autocompleteState.query}'</span>
-              </div>
-            {/if}
-          {/each}
+          {#if flatItems.length > 0}
+            <ul class="ac-results-list" role="listbox" id="ac-listbox-mobile" aria-label="Search results">
+              {#each flatItems as item, i (item.objectID)}
+                <AutocompleteItem
+                  {item}
+                  id={`ac-opt-mobile-${i}`}
+                  active={activeIndex === i}
+                  onClick={() => handleItemClick(item)}
+                />
+              {/each}
+            </ul>
+          {:else if autocompleteState.query}
+            <div class="ac-empty">
+              <svg class="ac-empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <span>No results for '{autocompleteState.query}'</span>
+            </div>
+          {/if}
           {#if autocompleteState.query}
             <div class="ac-footer">
               <a
@@ -515,6 +583,11 @@
       on:keydown={handleKeyDown}
       on:input={handleInputChange}
       {...inputProps}
+      role="combobox"
+      aria-expanded={isFocused && autocompleteState.isOpen && flatItems.length > 0}
+      aria-controls="ac-listbox-desktop"
+      aria-autocomplete="list"
+      aria-activedescendant={activeIndex >= 0 ? `ac-opt-desktop-${activeIndex}` : undefined}
     />
     {#if !isFocused}
       <span class="ac-kbd">/</span>
@@ -527,22 +600,25 @@
           style="transform-origin: center top;"
         >
           <div class="ac-panel-divider"></div>
-          {#each autocompleteState.collections as collection}
-            {#if filterValidItems(collection.items).length > 0}
-              <ul class="ac-results-list">
-                {#each filterValidItems(collection.items) as item (item.objectID)}
-                  <AutocompleteItem {item} onClick={() => handleItemClick(item)} />
-                {/each}
-              </ul>
-            {:else if autocompleteState.query}
-              <div class="ac-empty">
-                <svg class="ac-empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
-                <span>No results for '{autocompleteState.query}'</span>
-              </div>
-            {/if}
-          {/each}
+          {#if flatItems.length > 0}
+            <ul class="ac-results-list" role="listbox" id="ac-listbox-desktop" aria-label="Search results">
+              {#each flatItems as item, i (item.objectID)}
+                <AutocompleteItem
+                  {item}
+                  id={`ac-opt-desktop-${i}`}
+                  active={activeIndex === i}
+                  onClick={() => handleItemClick(item)}
+                />
+              {/each}
+            </ul>
+          {:else if autocompleteState.query}
+            <div class="ac-empty">
+              <svg class="ac-empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <span>No results for '{autocompleteState.query}'</span>
+            </div>
+          {/if}
           {#if autocompleteState.query}
             <div class="ac-footer">
               <a

--- a/src/svelte/components/AutocompleteItem.svelte
+++ b/src/svelte/components/AutocompleteItem.svelte
@@ -4,16 +4,21 @@
 
   export let item: any;
   export let onClick: () => void;
+  export let active = false;
+  export let id: string | undefined = undefined;
 </script>
 
 <li
-  class="flex items-center gap-3 px-4 py-2.5 border-b border-weeb-border bg-transparent cursor-pointer transition-colors duration-150 hover:bg-weeb-surface last:border-b-0 group"
+  class="flex items-center gap-3 px-4 py-2.5 border-b border-weeb-border cursor-pointer transition-colors duration-150 hover:bg-weeb-surface last:border-b-0 group"
+  class:bg-weeb-surface={active}
+  class:ac-item-active={active}
   data-autocomplete-item
+  {id}
   on:click={onClick}
   on:keypress={(e) => { if (e.key === 'Enter') onClick(); }}
   role="option"
-  aria-selected="false"
-  tabindex="0"
+  aria-selected={active}
+  tabindex="-1"
 >
   <div class="flex-shrink-0 rounded-md overflow-hidden" style="width: 37px; height: 56px;">
     <SafeImage
@@ -25,7 +30,11 @@
     />
   </div>
   <div class="flex-1 min-w-0 flex flex-col justify-center">
-    <span class="text-sm font-medium text-weeb-fg whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-weeb-accent transition-colors">
+    <span
+      class="text-sm font-medium whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-weeb-accent transition-colors"
+      class:text-weeb-accent={active}
+      class:text-weeb-fg={!active}
+    >
       {item.title_en || ''}
     </span>
     <span class="text-xs text-weeb-fg-muted">

--- a/tests/e2e/a11y-search.spec.ts
+++ b/tests/e2e/a11y-search.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { waitForHomepage } from './helpers';
+
+// The search combobox is rendered twice (mobile + desktop); the desktop input
+// is the one visible on the Desktop Chrome/Firefox projects CI runs. These
+// tests assert the keyboard-navigation + ARIA combobox contract on it.
+const QUERY = 'Naruto';
+
+test.describe('Search autocomplete keyboard navigation (a11y)', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+
+    // The autocomplete shows a loading skeleton until Algolia finishes its
+    // async client-side init, so wait for the real input to appear rather than
+    // point-checking. On mobile projects it is display:none and never becomes
+    // visible, so the wait times out and we skip (the contract is identical,
+    // but these locators target the desktop markup).
+    const desktopInput = page.locator('input.ac-input--desktop');
+    const visible = await desktopInput
+      .waitFor({ state: 'visible', timeout: 15000 })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!visible, 'desktop search input is not visible on this viewport');
+  });
+
+  test('exposes combobox + listbox roles once results load', async ({ page }) => {
+    const search = page.locator('input.ac-input--desktop');
+    await search.click();
+    await search.fill(QUERY);
+
+    const options = page.locator('#ac-listbox-desktop [role="option"]');
+    await expect(options.first()).toBeVisible({ timeout: 15000 });
+
+    await expect(search).toHaveAttribute('role', 'combobox');
+    await expect(search).toHaveAttribute('aria-controls', 'ac-listbox-desktop');
+    await expect(search).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('#ac-listbox-desktop')).toHaveAttribute('role', 'listbox');
+  });
+
+  test('Arrow keys move the highlight and sync aria-activedescendant', async ({ page }) => {
+    const search = page.locator('input.ac-input--desktop');
+    const options = page.locator('#ac-listbox-desktop [role="option"]');
+    await search.click();
+    await search.fill(QUERY);
+    await expect(options.first()).toBeVisible({ timeout: 15000 });
+
+    // Nothing highlighted until the user arrows into the list.
+    await expect(search).not.toHaveAttribute('aria-activedescendant', /.+/);
+
+    await search.press('ArrowDown');
+    await expect(search).toHaveAttribute('aria-activedescendant', 'ac-opt-desktop-0');
+    await expect(options.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+    await search.press('ArrowDown');
+    await expect(search).toHaveAttribute('aria-activedescendant', 'ac-opt-desktop-1');
+    await expect(options.nth(0)).toHaveAttribute('aria-selected', 'false');
+    await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+    await search.press('ArrowUp');
+    await expect(search).toHaveAttribute('aria-activedescendant', 'ac-opt-desktop-0');
+    await expect(options.nth(0)).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('Enter on the highlighted option opens that show', async ({ page }) => {
+    const search = page.locator('input.ac-input--desktop');
+    const options = page.locator('#ac-listbox-desktop [role="option"]');
+    await search.click();
+    await search.fill(QUERY);
+    await expect(options.first()).toBeVisible({ timeout: 15000 });
+
+    await search.press('ArrowDown');
+    await search.press('Enter');
+    await expect(page).toHaveURL(/\/show\//, { timeout: 15000 });
+  });
+
+  test('Enter with no highlight runs a full search', async ({ page }) => {
+    const search = page.locator('input.ac-input--desktop');
+    const options = page.locator('#ac-listbox-desktop [role="option"]');
+    await search.click();
+    await search.fill(QUERY);
+    await expect(options.first()).toBeVisible({ timeout: 15000 });
+
+    // No ArrowDown → no active option → Enter falls through to /search.
+    await search.press('Enter');
+    await expect(page).toHaveURL(/\/search\?query=Naruto/i, { timeout: 15000 });
+  });
+});


### PR DESCRIPTION
## What
The search autocomplete could only be used with a mouse. Algolia's `autocomplete-core` exposes keyboard handling via `getInputProps().onKeyDown`, but that **React-style prop never fires when spread into a Svelte input** — so arrow keys and Enter did nothing on the suggestions. This wires real keyboard navigation and the full ARIA combobox pattern.

## Behaviour
- **ArrowUp / ArrowDown** move a highlighted result (wraps at the ends).
- **Enter** opens the highlighted show; with nothing highlighted it runs a full `/search?query=…`.
- Highlight **resets** when the query changes or the panel closes, so Enter can't act on a stale row.

## ARIA
- Input: `role="combobox"` + `aria-expanded` / `aria-controls` / `aria-autocomplete` / `aria-activedescendant`.
- Results: `role="listbox"` with `role="option"` children; `aria-selected` tracks the highlight; the active row scrolls into view.
- Options carry per-device ids (`ac-opt-desktop-*` / `ac-opt-mobile-*`) since both panels render — keeps the DOM valid.

## Tests
New `tests/e2e/a11y-search.spec.ts`, validated live against staging Algolia on **chromium + firefox**:
1. combobox + listbox roles present once results load
2. Arrow keys move the highlight and sync `aria-activedescendant` (down, down, up)
3. Enter on the highlighted option opens that show (`/show/…`)
4. Enter with no highlight runs a full search (`/search?query=…`)

Also verified: existing `anime-search` + `a11y-modal` suites pass, `svelte-check` zero new errors, 82/82 unit tests.

> Discovered along the way: the previous `anime-search.spec.ts` never actually found the search input (wrong `input[type=search]` selector), so search had **no real e2e coverage** before this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)