### PR TITLE
fix(config): serve client config from layout data, drop redundant /config.json fetches

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,10 +16,17 @@
     showInstantFeedback,
     hideNavigationFeedback
   } from '$lib/client/global-ui';
+  import { configStore } from '../svelte/stores/config';
   import '../scss/base.scss';
   import '../styles/design-tokens.css';
 
   export let data;
+
+  // Config is loaded once (build-time import → locals → layout data). Seed the
+  // client store from it so nothing needs to re-fetch /config.json. Runs during
+  // both SSR and client hydration; the store is shared but config isn't
+  // per-user, so that's safe.
+  configStore.hydrate(data.config);
 
   // One QueryClient for the whole app via context. In the browser this is
   // the shared singleton; during SSR each layout render gets a fresh

--- a/src/services/config-loader.ts
+++ b/src/services/config-loader.ts
@@ -1,5 +1,6 @@
 // Config loader that ensures config is loaded before anything else
 import type { IConfig } from '../config/interfaces';
+import { configStore } from '../svelte/stores/config';
 
 let configPromise: Promise<IConfig> | null = null;
 let configData: IConfig | null = null;
@@ -90,6 +91,21 @@ async function initializeConfigSSR(): Promise<IConfig> {
 async function initializeConfigClient(): Promise<IConfig> {
   if (configData) {
     return configData;
+  }
+
+  // Prefer the config the root layout already hydrated from build-time data,
+  // avoiding a redundant /config.json round-trip. Falls through to fetch only
+  // if nothing populated the store yet.
+  const hydrated = configStore.get();
+  if (hydrated) {
+    configData = hydrated;
+    // @ts-ignore — legacy globals some code still reads
+    window.global = window.global || {};
+    // @ts-ignore
+    window.global.config = hydrated;
+    // @ts-ignore
+    window.config = hydrated;
+    return hydrated;
   }
 
   if (!configPromise) {

--- a/src/svelte/components/ConfigProvider.svelte
+++ b/src/svelte/components/ConfigProvider.svelte
@@ -1,24 +1,15 @@
 <script lang="ts">
-  import { setContext, onMount } from 'svelte';
+  import { setContext } from 'svelte';
+  import { configStore } from '../stores/config';
 
-  let config: any = {
+  // Config is already hydrated by the root layout from build-time config, so
+  // read it from the store instead of re-fetching /config.json. Fall back to a
+  // minimal default only if the store somehow isn't populated yet.
+  const config: any = configStore.get() ?? {
     cdn_user_url: 'https://cdn.weeb.vip/users'
   };
 
-  // Set context immediately with fallback config
   setContext('config', config);
-
-  onMount(async () => {
-    try {
-      const response = await fetch('/config.json');
-      const newConfig = await response.json();
-      // Update the config object in place
-      Object.assign(config, newConfig);
-    } catch (error) {
-      console.warn('Failed to load config:', error);
-      // Keep using fallback config
-    }
-  });
 </script>
 
 <slot />

--- a/src/svelte/stores/config.ts
+++ b/src/svelte/stores/config.ts
@@ -3,14 +3,26 @@ import type { IConfig } from '../../config/interfaces';
 
 // Create a writable store for config
 function createConfigStore() {
-  const { subscribe, set, update } = writable<IConfig | null>(null);
+  const { subscribe, set: _set, update } = writable<IConfig | null>(null);
+  // Mirror the current value so init()/get() can read it synchronously.
+  let current: IConfig | null = null;
+  const set = (config: IConfig | null) => { current = config; _set(config); };
   let isLoading = false;
   let loadPromise: Promise<IConfig | null> | null = null;
 
   return {
     subscribe,
-    // Initialize the config store by fetching from HTTP
+    // Populate synchronously from the server-provided (build-time) config that
+    // the root layout already loads, so the client never re-fetches
+    // /config.json. Idempotent — the first non-null value wins.
+    hydrate: (config: IConfig | null | undefined) => {
+      if (config && !current) set(config);
+    },
+    // Ensure config is available. Returns immediately once hydrated (the common
+    // case); only falls back to an HTTP fetch if nothing populated the store.
     init: async () => {
+      if (current) return current;
+
       // Prevent multiple simultaneous loads
       if (isLoading && loadPromise) {
         return loadPromise;
@@ -59,12 +71,8 @@ function createConfigStore() {
     },
     // Update config if needed
     setConfig: (config: IConfig) => set(config),
-    // Get specific config value synchronously
-    get: (): IConfig | null => {
-      let value: IConfig | null = null;
-      subscribe(val => value = val)();
-      return value;
-    }
+    // Get the current config synchronously
+    get: (): IConfig | null => current
   };
 }
 

--- a/tests/e2e/config-loading.spec.ts
+++ b/tests/e2e/config-loading.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { waitForHomepage } from './helpers';
+
+// Config is loaded once at build time and handed to the client via the root
+// layout's load data. The client consumers (config store, config-loader data
+// layer, profile context) read that instead of re-fetching /config.json. This
+// test locks in "no redundant client config fetch" while proving config still
+// actually resolves (search needs config.algolia_index to return results).
+test.describe('Config loading', () => {
+  test.setTimeout(60000);
+
+  test('client uses layout-provided config without re-fetching /config.json', async ({ page }) => {
+    const configRequests: string[] = [];
+    page.on('request', (r) => {
+      if (r.url().includes('/config.json')) configRequests.push(r.url());
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+
+    // Prove config actually resolved: the search index name comes from config,
+    // so getting results means the hydrated config reached the store.
+    const search = page.locator('input.ac-input--desktop');
+    const desktop = await search
+      .waitFor({ state: 'visible', timeout: 15000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (desktop) {
+      await search.click();
+      await search.fill('Naruto');
+      await expect(
+        page.locator('#ac-listbox-desktop [role="option"]').first()
+      ).toBeVisible({ timeout: 15000 });
+    }
+
+    // The point of the consolidation: zero redundant /config.json round-trips.
+    expect(
+      configRequests,
+      `unexpected /config.json fetches: ${configRequests.join(', ')}`
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What
Config is loaded **once at build time** (static JSON import → `locals.config` → root `+layout.server.ts` load data). But three separate client paths each re-fetched `/config.json` for that same data:

- the `configStore` (`configStore.init()`) — 5 consumers
- the `config-loader` data layer (`ensureConfigLoaded`, used by `queries.ts`)
- `ConfigProvider` (profile context)

## Change
- `+layout.svelte` seeds `configStore` from `data.config` on hydration (`configStore.hydrate()`), so the store holds the build-time config immediately — no fetch.
- `configStore.init()` and `config-loader`'s client path return the hydrated config first, keeping the `/config.json` fetch only as a defensive fallback.
- `ConfigProvider` reads the store instead of fetching.

## Also a correctness fix (why this is `fix:`, not `refactor:`)
`ConfigProvider` previously exposed a `{cdn_user_url}`-only fallback via `setContext('config', …)` and `Object.assign`'d the real config in **asynchronously after a fetch**. Anything reading `getContext('config')` on mount got **incomplete** config until that resolved. It now reads the fully-hydrated store synchronously, so consumers always see complete config.

## Tests
New `tests/e2e/config-loading.spec.ts` (chromium + firefox):
- Asserts **zero** `/config.json` requests on the client during a homepage + search flow (was up to 3).
- Proves config still resolves — search returns Algolia results, which requires `config.algolia_index`.

Verified: `a11y-search` + `anime-search` regression suites pass, `svelte-check` zero new errors, 82/82 unit tests.

## Release
Cut as its own patch release so a client-data-layer change has clean attribution and one-version rollback, rather than riding an unrelated fix. The SSR path (`hooks` → `locals.config`) already loaded config once and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)