### PR TITLE
fix(auth): SSR user hydration imported non-existent getUserQuery, always fell back

### DIFF
--- a/src/svelte/components/AuthInitializer.svelte
+++ b/src/svelte/components/AuthInitializer.svelte
@@ -49,15 +49,7 @@
 
           // Fetch user data for PostHog identification
           try {
-            const queriesModule = await import('../../services/queries');
-            // Type-level cast only: 'getUserQuery' is not exported by this module,
-            // so it is undefined at runtime and the call below throws into the
-            // catch fallback (existing behavior, intentionally preserved).
-            const { getUserQuery } = queriesModule as typeof queriesModule & {
-              getUserQuery: typeof queriesModule.getUser;
-            };
-            const queryConfig = getUserQuery();
-            const userData = await queryConfig.queryFn();
+            const userData = await getUser().queryFn();
 
             loggedInStore.setLoggedIn({
               id: userData.id,


### PR DESCRIPTION
## Summary

Follow-up to the latent bug found in #62: the SSR-auth branch of `AuthInitializer.svelte` dynamically imported `getUserQuery` from `services/queries`, which doesn't exist (the export is `getUser`). The destructured value was `undefined`, so the call threw on every SSR-authenticated page load and the `catch` fell back to `setLoggedIn()` **without user data** — meaning PostHog identification never ran for SSR-authenticated visits.

Fix: call the statically imported `getUser().queryFn()` directly (same query the non-SSR path uses). The dynamic import and the type cast documenting the broken behavior are gone.

Verified: svelte-check gate passes (0 errors, baseline 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)