### PR TITLE
fix: remove never-executing mutation status wrappers and write-only animeStatuses tracking

### DIFF
--- a/src/svelte/components/CurrentlyAiringPage.svelte
+++ b/src/svelte/components/CurrentlyAiringPage.svelte
@@ -6,9 +6,8 @@
   import SafeImage from './SafeImage.svelte';
   import { initializeQueryClient } from '../services/query-client';
   import { fetchCurrentlyAiringWithDatesAndEpisodes } from '../../services/queries';
-  import { useAddAnimeWithToast, useDeleteAnimeWithToast } from '../utils/anime-actions';
+  import { useAddAnimeWithToast } from '../utils/anime-actions';
   import { Status } from '../../gql/graphql';
-  import type { UserAnimeInput } from '../../gql/graphql';
   import { GetImageFromAnime, getYearUTC } from '../../services/utils';
   import { findNextEpisode, getAirTimeDisplay } from '../../services/airTimeUtils';
   import { animeNotificationService } from '../../services/animeNotifications';
@@ -19,8 +18,6 @@
   export let ssrData: any = null;
   export let ssrError: string | null = null;
   export let isTokenExpired: boolean = false;
-
-  let animeStatuses: Record<string, 'idle' | 'loading' | 'success' | 'error'> = {};
 
   // Initialize query client
   const queryClient = initializeQueryClient();
@@ -78,48 +75,6 @@
 
   // Create enhanced mutations with toast handling
   const upsertAnimeMutation = useAddAnimeWithToast();
-
-  // Extend with custom status tracking callbacks
-  type UpsertMutateOptions = {
-    onSuccess?: (data: unknown, vars: { animeID: string }) => void;
-    onError?: (error: unknown, vars: { animeID: string }) => void;
-  };
-  type UpsertMutateFn = (variables: { input: UserAnimeInput }, options?: UpsertMutateOptions) => unknown;
-  const patchableUpsertMutation = upsertAnimeMutation as typeof upsertAnimeMutation & { mutate: UpsertMutateFn };
-  const originalUpsertMutate = patchableUpsertMutation.mutate;
-  patchableUpsertMutation.mutate = (variables, options = {}) => {
-    // Update status tracking on success
-    const originalOnSuccess = options.onSuccess;
-    options.onSuccess = (data, vars) => {
-      // Update anime status
-      animeStatuses = { ...animeStatuses };
-      const animeId = vars.animeID;
-      Object.keys(animeStatuses).forEach(key => {
-        if (key.includes(animeId)) {
-          animeStatuses[key] = 'success';
-        }
-      });
-      if (originalOnSuccess) originalOnSuccess(data, vars);
-    };
-
-    // Update status tracking on error
-    const originalOnError = options.onError;
-    options.onError = (error, vars) => {
-      // Update anime status to error
-      const animeId = vars.animeID;
-      animeStatuses = { ...animeStatuses };
-      Object.keys(animeStatuses).forEach(key => {
-        if (key.includes(animeId)) {
-          animeStatuses[key] = 'error';
-        }
-      });
-      if (originalOnError) originalOnError(error, vars);
-    };
-
-    return originalUpsertMutate(variables, options);
-  };
-
-  const deleteAnimeMutation = useDeleteAnimeWithToast();
 
   // Process currently airing data for airing page with categories
   function processCurrentlyAiring(data: any) {
@@ -194,36 +149,7 @@
             .sort((a, b) => a.airingInfo.nextEpisodeDate.getTime() - b.airingInfo.nextEpisodeDate.getTime());
   }
 
-  function handleStatusChange(event: CustomEvent) {
-    const { animeId, status } = event.detail;
-    $upsertAnimeMutation.mutate({ input: { animeID: animeId, status } });
-  }
-
-  function handleDelete(event: CustomEvent) {
-    console.log('🗑️ handleDelete called with:', event.detail);
-    const { animeId } = event.detail;
-    console.log('🗑️ Calling deleteAnimeMutation with animeId:', animeId);
-    $deleteAnimeMutation.mutate(animeId);
-  }
-
-  function clearAnimeStatus(animeId: string) {
-    console.log('🧹 clearAnimeStatus called with animeId:', animeId);
-    // Call the delete mutation first
-    console.log('🗑️ Calling deleteAnimeMutation from clearAnimeStatus with animeId:', animeId);
-    $deleteAnimeMutation.mutate(animeId);
-
-    // Clear status for all keys that contain this animeId
-    const updated = { ...animeStatuses };
-    Object.keys(updated).forEach(key => {
-      if (key.includes(animeId)) {
-        delete updated[key];
-      }
-    });
-    animeStatuses = updated;
-  }
-
-  function handleAddAnime(id: string, animeId: string) {
-    animeStatuses[id] = 'loading';
+  function handleAddAnime(animeId: string) {
     $upsertAnimeMutation.mutate({ input: { animeID: animeId, status: Status.Plantowatch } });
   }
 
@@ -689,7 +615,7 @@
                     </span>
                   </div>
                   {#if !isInList}
-                    <button class="show-add-btn" title="Add to list" aria-label="Add to list" on:click|preventDefault|stopPropagation={() => handleAddAnime(entry.id, entry.airingInfo.id)}>
+                    <button class="show-add-btn" title="Add to list" aria-label="Add to list" on:click|preventDefault|stopPropagation={() => handleAddAnime(entry.airingInfo.id)}>
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                     </button>
                   {/if}

--- a/src/svelte/components/HomepageSSR.svelte
+++ b/src/svelte/components/HomepageSSR.svelte
@@ -14,9 +14,6 @@
     fetchCurrentlyAiring,
     fetchSeasonalAnime, fetchCurrentlyAiringWithDates
   } from '../../services/queries';
-  import { useAddAnimeWithToast, useDeleteAnimeWithToast } from '../utils/anime-actions';
-  import { Status } from '../../gql/graphql';
-  import type { UserAnimeInput } from '../../gql/graphql';
   import { GetImageFromAnime, getYearUTC } from '../../services/utils';
   import { findNextEpisode, getAirTimeDisplay } from '../../services/airTimeUtils';
   import { preferencesStore, getAnimeTitle } from '../stores/preferences';
@@ -35,12 +32,6 @@
   // SSR props
   type DebugWindow = Window & { refreshHomepageData?: () => void };
 
-  type UpsertMutateOptions = {
-    onSuccess?: (data: unknown, vars: { animeID: string }) => void;
-    onError?: (error: unknown, vars: { animeID: string }) => void;
-  };
-  type UpsertMutateFn = (variables: { input: UserAnimeInput }, options?: UpsertMutateOptions) => unknown;
-
   export let homeData: any;
   export let currentlyAiringData: any;
   export let seasonalData: any;
@@ -49,7 +40,6 @@
 
   let selectedSeason = currentSeason;
   let isDropdownOpen = false;
-  let animeStatuses: Record<string, 'idle' | 'loading' | 'success' | 'error'> = {};
 
   // Initialize query client for mutations only
   const queryClient = initializeQueryClient();
@@ -249,45 +239,6 @@
     };
   });
 
-  // Create mutations with success callbacks
-  // Create enhanced mutations with toast handling
-  const upsertAnimeMutation = useAddAnimeWithToast();
-  const deleteAnimeMutation = useDeleteAnimeWithToast();
-
-  // Extend upsert mutation with custom status tracking callbacks
-  const patchableUpsertMutation = upsertAnimeMutation as typeof upsertAnimeMutation & { mutate: UpsertMutateFn };
-  const originalUpsertMutate = patchableUpsertMutation.mutate;
-  patchableUpsertMutation.mutate = (variables, options = {}) => {
-    // Update status tracking on success
-    const originalOnSuccess = options.onSuccess;
-    options.onSuccess = (data, vars) => {
-      // Update anime status
-      animeStatuses = { ...animeStatuses };
-      Object.keys(animeStatuses).forEach(key => {
-        if (key.includes(vars.animeID)) {
-          animeStatuses[key] = 'success';
-        }
-      });
-      if (originalOnSuccess) originalOnSuccess(data, vars);
-    };
-
-    // Update status tracking on error
-    const originalOnError = options.onError;
-    options.onError = (error, vars) => {
-      // Update anime status to error
-      const animeId = vars.animeID;
-      animeStatuses = { ...animeStatuses };
-      Object.keys(animeStatuses).forEach(key => {
-        if (key.includes(animeId)) {
-          animeStatuses[key] = 'error';
-        }
-      });
-      if (originalOnError) originalOnError(error, vars);
-    };
-
-    return originalUpsertMutate(variables, options);
-  };
-
   // Process currently airing data
   function processCurrentlyAiring(data: any) {
     if (!data?.currentlyAiring) return [];
@@ -362,32 +313,6 @@
       .sort((a, b) => a.airingInfo.nextEpisodeDate.getTime() - b.airingInfo.nextEpisodeDate.getTime());
 
     return [...recentlyAired, ...futureEpisodes];
-  }
-
-  function handleStatusChange(event: CustomEvent) {
-    const { animeId, status } = event.detail;
-    $upsertAnimeMutation.mutate({ input: { animeID: animeId, status } });
-  }
-
-  function handleDelete(event: CustomEvent) {
-    const { animeId } = event.detail;
-    $deleteAnimeMutation.mutate(animeId);
-  }
-
-  function clearAnimeStatus(animeId: string) {
-    $deleteAnimeMutation.mutate(animeId);
-    const updated = { ...animeStatuses };
-    Object.keys(updated).forEach(key => {
-      if (key.includes(animeId)) {
-        delete updated[key];
-      }
-    });
-    animeStatuses = updated;
-  }
-
-  function handleAddAnime(id: string, animeId: string) {
-    animeStatuses[id] = 'loading';
-    $upsertAnimeMutation.mutate({ input: { animeID: animeId, status: Status.Plantowatch } });
   }
 
   // Process currently airing data from queries (with SSR fallback)


### PR DESCRIPTION
## Summary

Follow-up to latent bug #2 from #62. HomepageSSR and CurrentlyAiringPage monkey-patched `.mutate` on the svelte-query mutation **store object** to track per-anime add status, but every caller invokes `$mutation.mutate` (the store **value**), so the wrapper never executed. It was broken in two more ways even if it had run: it read `vars.animeID` while the variables are shaped `{ input: { animeID } }`, and the `animeStatuses` record it maintained is never read by any template.

Rather than wiring up a three-layers-broken feature nothing displays, this removes the dead apparatus (−152 lines, +3):

- Both components: the `.mutate` monkey-patch, its `UpsertMutateFn`/`UpsertMateOptions` types, and the write-only `animeStatuses` state
- **HomepageSSR**: `handleStatusChange`, `handleDelete`, `clearAnimeStatus`, `handleAddAnime` and both mutation instances — all completely unreferenced in the template
- **CurrentlyAiringPage**: keeps its actually-used add-to-list button handler (minus the dead status write and unused `id` param); drops the unused delete mutation and `console.log` debug noise

No user-visible change: add/delete feedback already comes from the `useAddAnimeWithToast`/`useDeleteAnimeWithToast` toasts and query invalidation.

Verified: svelte-check 0 errors (baseline 0), jest 82/82, production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)