### PR TITLE
perf(data): stop show-page duplicate fetch + trim homepage over-fetch

### DIFF
--- a/src/services/api/graphql/queries.ts
+++ b/src/services/api/graphql/queries.ts
@@ -25,7 +25,7 @@ export const getHomePageData = graphql(/* GraphQL */`
                 episodes
             }
         }
-        newestAnime(limit:100) {
+        newestAnime(limit:20) {
             id
             anidbid
             thetvdbid

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -133,8 +133,13 @@
     console.error('🏃‍♂️ [ShowContent] SSR error:', ssrError);
   }
 
-  // Create query at top level (required for Svelte lifecycle)
-  showQueryStore = createQuery(fetchDetails(animeId));
+  // Create query at top level (required for Svelte lifecycle).
+  // Skip the client fetch when SSR already provided the details — otherwise
+  // this refetches the heaviest document in the app on every show view.
+  showQueryStore = createQuery({
+    ...fetchDetails(animeId),
+    enabled: !ssrAnimeData
+  });
 
   // Subscribe to query changes
   showQuery = $showQueryStore;


### PR DESCRIPTION
## Summary

Two low-risk data-fetching wins from the performance review.

**1. Show page fired a duplicate heavy GraphQL round-trip on every view.**
`src/routes/show/[id]/+page.server.ts` already fetches `getAnimeDetailsByID` (the heaviest document in the app — full `episodes[]` with synopsis), but `ShowContent.svelte` then created a client query for the same thing with no `initialData`/`enabled` guard, so it refetched immediately on mount. Its sibling `CharactersWithStaff.svelte` already does this correctly with `enabled: !ssrCharactersData` — this mirrors that pattern (`enabled: !ssrAnimeData`). The reactive block that consumes the query already guards on `.data`, so SSR values persist when the query is disabled.

**2. Homepage over-fetched `newestAnime` 100 → renders 14.**
`newestAnime(limit:100)` in the home query, sliced to 14 in `HomepageSSR`. Lowered to 20 (small buffer, matches `topRatedAnime`). Cuts ~80 unused anime objects from the gateway response and, since this data is serialized into the SSR HTML, from the hydration payload too.

## Verification
- svelte-check 0 errors / 0 warnings; production build passes
- Drove the built adapter-node server: show page renders from SSR data (title/detail present), homepage renders its Newest row intact
- Note: a clean client-request count wasn't possible in the local preview (its SSR hits the staging gateway while the client config points at prod, which fails cross-origin from localhost) — the guard is verified at code level against the established sibling pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)