### PR TITLE
perf(images): CDN image resizing via Cloudflare (prod-gated) + staging-URL fix

### DIFF
--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -5,4 +5,7 @@ export interface IConfig {
   cdn_url: string;
   cdn_user_url: string;
   posthog_api_key?: string;
+  /** Enable Cloudflare Image Resizing (/cdn-cgi/image/) on CDN URLs. Production only —
+   * staging is not fronted by Cloudflare, so transforms would 404 there. */
+  cdn_image_resize?: boolean;
 }

--- a/src/config/static/production/index.json
+++ b/src/config/static/production/index.json
@@ -4,5 +4,6 @@
   "algolia_index": "anime",
   "cdn_url": "https://cdn.weeb.vip/weeb",
   "cdn_user_url": "https://cdn.weeb.vip/weeb-user",
-  "posthog_api_key": "phc_MbyMDQJkiLR9NSfSGSpEhA1RSwu79mROuedzQvxgxoI"
+  "posthog_api_key": "phc_MbyMDQJkiLR9NSfSGSpEhA1RSwu79mROuedzQvxgxoI",
+  "cdn_image_resize": true
 }

--- a/src/svelte/components/AiringStripCard.svelte
+++ b/src/svelte/components/AiringStripCard.svelte
@@ -29,6 +29,7 @@
       alt={title}
       className="airing-poster-img"
       fallbackSrc="/assets/not found.jpg"
+      cdnWidth={160}
     />
   </div>
   <div class="airing-info">

--- a/src/svelte/components/CurrentlyAiringPage.svelte
+++ b/src/svelte/components/CurrentlyAiringPage.svelte
@@ -9,6 +9,7 @@
   import { useAddAnimeWithToast } from '../utils/anime-actions';
   import { Status } from '../../gql/graphql';
   import { GetImageFromAnime, getYearUTC } from '../../services/utils';
+  import { getSafeImageUrl, resizeCdnUrl } from '../utils/image';
   import { findNextEpisode, getAirTimeDisplay } from '../../services/airTimeUtils';
   import { animeNotificationService } from '../../services/animeNotifications';
   import { preferencesStore, getAnimeTitle } from '../stores/preferences';
@@ -592,7 +593,7 @@
                 <a href="/show/{entry.airingInfo.id}" class="show-card" data-anime-id={entry.airingInfo.id} data-in-list={entry.airingInfo.userAnime != null ? 'true' : 'false'} on:click|preventDefault={() => navigateToShow(entry.airingInfo.id)}>
                   <div class="show-poster">
                     <img
-                      src={`https://cdn.weeb.vip/weeb-staging/${encodeURIComponent(GetImageFromAnime(entry.airingInfo))}`}
+                      src={resizeCdnUrl(getSafeImageUrl(GetImageFromAnime(entry.airingInfo)), 160)}
                       alt={title}
                       loading="lazy"
                       on:error={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
@@ -709,7 +710,7 @@
               <a href="/show/{entry.airingInfo.id}" class="cal-show-item" on:click|preventDefault={() => navigateToShow(entry.airingInfo.id)}>
                 <div class="cal-show-poster">
                   <img
-                    src={`https://cdn.weeb.vip/weeb-staging/${encodeURIComponent(GetImageFromAnime(entry.airingInfo))}`}
+                    src={resizeCdnUrl(getSafeImageUrl(GetImageFromAnime(entry.airingInfo)), 160)}
                     alt={title}
                     loading="lazy"
                     on:error={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}

--- a/src/svelte/components/HeroBanner.svelte
+++ b/src/svelte/components/HeroBanner.svelte
@@ -119,6 +119,7 @@
         fallbackSrc="/assets/not found.jpg"
         perTryTimeoutMs={3000}
         className="hero-bg-cover"
+        cdnWidth={1600}
         on:chosen={handleImageChosen}
       />
     </div>
@@ -191,6 +192,7 @@
       alt={title}
       className="hero-poster-img"
       fallbackSrc="/assets/not found.jpg"
+      cdnWidth={440}
     />
   </div>
 </div>

--- a/src/svelte/components/PosterCard.svelte
+++ b/src/svelte/components/PosterCard.svelte
@@ -29,6 +29,7 @@
       alt={title}
       className="poster-img"
       fallbackSrc="/assets/not found.jpg"
+      cdnWidth={360}
     />
     {#if score}
       <span class="score-badge">{typeof score === 'number' ? score.toFixed(1) : score}</span>

--- a/src/svelte/components/SafeImage.svelte
+++ b/src/svelte/components/SafeImage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getSafeImageUrl } from '../utils/image';
+  import { getSafeImageUrl, resizeCdnUrl } from '../utils/image';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import debug from '../../utils/debug';
 
@@ -14,6 +14,9 @@
   export let width: string | number | undefined = undefined;
   export let height: string | number | undefined = undefined;
   export let loading: 'lazy' | 'eager' | undefined = undefined;
+  /** Intended device-pixel width. When set, CDN sources are routed through
+   * Cloudflare Image Resizing (production only). Undefined = full-res (unchanged). */
+  export let cdnWidth: number | undefined = undefined;
 
   // New ordered loading props (like RacyImage)
   /** Ordered list of candidate URLs (first has highest priority) */
@@ -114,6 +117,13 @@
       // No sources or src provided
       debug.warn('No image sources or src provided');
       orderedSources = [getSafeImageUrl(src, path)];
+    }
+
+    // Route CDN sources through Cloudflare Image Resizing when a target width is
+    // given (no-op unless enabled in config, i.e. production). Applied before the
+    // preload race so the same URL is loaded, cached, and rendered.
+    if (cdnWidth) {
+      orderedSources = orderedSources.map(u => resizeCdnUrl(u, cdnWidth));
     }
 
     debug.log(`Racing ${orderedSources.length} image sources in parallel with priority order`);

--- a/src/svelte/utils/image.ts
+++ b/src/svelte/utils/image.ts
@@ -31,3 +31,36 @@ function escapeUri(str) {
       '%' + char.charCodeAt(0).toString(16).toUpperCase()
     );
 }
+
+/** True only when the loaded config opts in (production, which is Cloudflare-fronted). */
+function isCdnResizeEnabled(): boolean {
+  const config = configStore.get();
+  if (config) return config.cdn_image_resize === true;
+  // SSR/pre-config fallback: window global mirrors the layout config
+  if (typeof window !== 'undefined') {
+    return (window as any).global?.config?.cdn_image_resize === true;
+  }
+  return false;
+}
+
+/**
+ * Route a CDN image URL through Cloudflare Image Resizing when enabled:
+ *   https://cdn.weeb.vip/weeb/<slug>
+ *     -> https://cdn.weeb.vip/cdn-cgi/image/width=W,format=auto,quality=85,fit=cover/weeb/<slug>
+ * `width` is the intended device-pixel width (pass ~1.5-2x the CSS size for retina).
+ * Returns the URL unchanged when resizing is disabled, the URL isn't a CDN URL,
+ * already transformed, or unparseable — so it is always safe to call.
+ */
+export function resizeCdnUrl(url: string, width: number): string {
+  if (!width || !isCdnResizeEnabled()) return url;
+  if (!/^https?:\/\//i.test(url)) return url; // local assets (fallbacks) pass through
+  try {
+    const u = new URL(url);
+    if (!u.hostname.endsWith('cdn.weeb.vip')) return url;
+    if (u.pathname.startsWith('/cdn-cgi/image/')) return url; // don't double-transform
+    const opts = `width=${Math.round(width)},format=auto,quality=85,fit=cover`;
+    return `${u.origin}/cdn-cgi/image/${opts}${u.pathname}${u.search}`;
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
## Summary

The biggest byte win from the perf review: posters/banners were served **full-resolution and downscaled in CSS** (a 56px thumbnail downloading a full-size image, no WebP/AVIF). This routes CDN image URLs through Cloudflare Image Resizing — `/cdn-cgi/image/width=…,format=auto,quality=85,fit=cover/…` — so each image is delivered at ~display size and in a modern format.

## Safety design (production-gated)
Staging/dev are **not** Cloudflare-fronted, so transforms would 404 there. The resize is gated on a new `cdn_image_resize` config flag, set `true` **only in `production/index.json`**:
- `resizeCdnUrl()` is a no-op when the flag is off, and for non-CDN / local-asset / already-transformed URLs (unit-verified).
- Opt-in per usage via a new `SafeImage` `cdnWidth` prop — **every existing caller is unaffected** (default undefined = full-res). Wired into `PosterCard` (360), `AiringStripCard` (160), and the hero background (1600) + poster (440).

## Also fixes a correctness bug
`CurrentlyAiringPage` hardcoded the **`weeb-staging`** CDN path in production (schedule + calendar thumbnails). Now uses the config-driven `getSafeImageUrl` (+ resize).

## Verification
- svelte-check 0/0; production build passes
- `resizeCdnUrl` unit-checked: off→passthrough, on→correct URL, local/non-CDN/double-transform→safe
- Drove the built (production-config) server: all 53 CDN image requests correctly transformed to `/cdn-cgi/image/…` with the right per-component widths, **zero `weeb-staging` URLs**. (Actual image rendering can't be verified from here — the CDN blocks non-prod origins and Image Resizing isn't enabled yet.)

## ⚠️ Merge ordering
**Do not merge until Cloudflare Image Resizing is enabled on the `cdn.weeb.vip` zone and curl-verified** (Images → Transformations → Enable; Pro plan; proxied DNS). This PR flips the flag on at deploy, so merging before the feature is live will 404 all production images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)