### PR TITLE
fix: resolve streaming-platforms feature-flag async race

### DIFF
--- a/src/svelte/components/StreamingPlatforms.svelte
+++ b/src/svelte/components/StreamingPlatforms.svelte
@@ -1,9 +1,20 @@
 <script lang="ts">
-  import { isFeatureEnabled } from '../../utils/analytics';
+  import { onMount } from 'svelte';
+  import { isFeatureEnabled, onFeatureFlags } from '../../utils/analytics';
 
   export let platforms: Array<{ platform: string; name?: string | null; url: string }> | null | undefined = undefined;
 
-  const featureEnabled = typeof window !== 'undefined' && isFeatureEnabled('animeschedule-integration');
+  // PostHog loads flags asynchronously after init, so evaluating once at
+  // component creation races the flag load and gets stuck on `false`. Read it
+  // on mount and re-read whenever flags (re)load so the section appears once
+  // the flag resolves.
+  let featureEnabled = false;
+  onMount(() => {
+    featureEnabled = isFeatureEnabled('animeschedule-integration');
+    onFeatureFlags(() => {
+      featureEnabled = isFeatureEnabled('animeschedule-integration');
+    });
+  });
 
   const platformIcons: Record<string, string> = {
     crunchyroll: 'https://img.animeschedule.net/production/assets/public/img/streams/crunchyroll.png',


### PR DESCRIPTION
## Problem
Flag `animeschedule-integration` is on and the API returns streaming data, but the "Watch on" section never renders on the client.

## Root cause
`StreamingPlatforms.svelte` evaluated the flag **once, synchronously, at component creation**:
```js
const featureEnabled = ... && isFeatureEnabled('animeschedule-integration');
```
PostHog loads flags **asynchronously** after init, so at mount the flag isn't loaded yet → returns `false`. Being a `const`, it never re-evaluates when flags arrive, so the section stays hidden even with the flag fully enabled.

## Fix
Read the flag in `onMount` and re-read it in an `onFeatureFlags` callback (fires when flags load/reload), assigning to a reactive `let` so the section appears once the flag resolves.

## Verified
`yarn check`: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)