### PR TITLE
feat: server-side PostHog flag evaluation (SSR-safe gating)

### DIFF
--- a/src/lib/server/posthog.ts
+++ b/src/lib/server/posthog.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-side PostHog feature-flag evaluation.
+ *
+ * Client-only flag checks (`window.posthog.isFeatureEnabled`) can't gate
+ * server-rendered content — the client flag load races hydration, so a flag
+ * that's on can still render nothing on first paint. Evaluating here, in a
+ * SvelteKit `load`, bakes the decision into the SSR HTML.
+ *
+ * Usage from a `+page.server.ts` / `+layout.server.ts` load:
+ *   import { isFeatureEnabled, getFeatureFlags } from '$lib/server/posthog';
+ *   const enabled = await isFeatureEnabled('my-flag', config, cookies);
+ *   const flags   = await getFeatureFlags(['a', 'b'], config, cookies); // one call
+ */
+import type { Cookies } from '@sveltejs/kit';
+import type { IConfig } from '../../config/interfaces';
+
+const POSTHOG_HOST = 'https://us.i.posthog.com';
+
+type FlagMap = Record<string, boolean | string>;
+
+/**
+ * Reuse the visitor's PostHog distinct_id (from the `ph_<key>_posthog` cookie)
+ * so rollout bucketing stays consistent with the client; fall back to a random
+ * id for anonymous requests.
+ */
+function distinctIdFrom(apiKey: string, cookies: Cookies): string {
+  const phCookie = cookies.get(`ph_${apiKey}_posthog`);
+  if (phCookie) {
+    try {
+      const parsed = JSON.parse(phCookie);
+      if (parsed?.distinct_id) return parsed.distinct_id as string;
+    } catch {
+      /* malformed cookie — fall through to a random id */
+    }
+  }
+  return crypto.randomUUID();
+}
+
+/** One `/decide` round-trip → the raw flag map (empty on missing key/error). */
+async function decide(config: IConfig, cookies: Cookies): Promise<FlagMap> {
+  const apiKey = config?.posthog_api_key;
+  if (!apiKey) return {};
+
+  const res = await fetch(`${POSTHOG_HOST}/decide/?v=3`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      api_key: apiKey,
+      distinct_id: distinctIdFrom(apiKey, cookies),
+      // `environment` powers env-scoped flag targeting (staging vs production)
+      person_properties: { environment: config?.environment || 'production' }
+    })
+  });
+  if (!res.ok) return {};
+  const data: any = await res.json();
+  return (data?.featureFlags as FlagMap) ?? {};
+}
+
+/** Evaluate a single feature flag server-side. Returns false on any error. */
+export async function isFeatureEnabled(
+  flagKey: string,
+  config: IConfig,
+  cookies: Cookies
+): Promise<boolean> {
+  try {
+    const flags = await decide(config, cookies);
+    return !!flags[flagKey];
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Evaluate several flags in a single `/decide` call. Returns a map of
+ * key → boolean, defaulting every requested key to false on error.
+ */
+export async function getFeatureFlags(
+  flagKeys: string[],
+  config: IConfig,
+  cookies: Cookies
+): Promise<Record<string, boolean>> {
+  try {
+    const flags = await decide(config, cookies);
+    return Object.fromEntries(flagKeys.map((k) => [k, !!flags[k]]));
+  } catch {
+    return Object.fromEntries(flagKeys.map((k) => [k, false]));
+  }
+}

--- a/src/routes/show/[id]/+page.server.ts
+++ b/src/routes/show/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from './$types';
 // (it already had: missing userAnime.episodes)
 import { getAnimeDetailsByID, queryCharactersAndStaffByAnimeID } from '../../../services/api/graphql/queries';
 import { createSSRGraphQLClient, cookieHeaderFrom } from '$lib/server/ssr-graphql';
+import { isFeatureEnabled } from '$lib/server/posthog';
 
 export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   const { id } = params;
@@ -20,6 +21,7 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   let animeData: any = null;
   let charactersData: any = null;
   let error: string | null = null;
+  let streamingEnabled = false;
 
   try {
     // Forward the user's cookies — the gateway authenticates via cookie,
@@ -28,10 +30,12 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
     // and every show rendered as "not on list" even when it was.
     const client = createSSRGraphQLClient(config.graphql_host, cookieHeaderFrom(cookies));
 
-    const [animeResponse, charactersResponse] = await Promise.all([
+    const [animeResponse, charactersResponse, flagEnabled] = await Promise.all([
       client.request(getAnimeDetailsByID, { id }),
-      client.request(queryCharactersAndStaffByAnimeID, { animeId: id })
+      client.request(queryCharactersAndStaffByAnimeID, { animeId: id }),
+      isFeatureEnabled('animeschedule-integration', config, cookies)
     ]);
+    streamingEnabled = flagEnabled;
 
     animeData = animeResponse;
     charactersData = charactersResponse;
@@ -59,6 +63,7 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
     animeImage,
     ssrAnimeData: animeData,
     ssrCharactersData: charactersData,
-    ssrError: error
+    ssrError: error,
+    streamingEnabled
   };
 };

--- a/src/routes/show/[id]/+page.svelte
+++ b/src/routes/show/[id]/+page.svelte
@@ -17,5 +17,6 @@
     ssrAnimeData={data.ssrAnimeData}
     ssrCharactersData={data.ssrCharactersData}
     ssrError={data.ssrError}
+    streamingEnabled={data.streamingEnabled}
   />
 {/key}

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -24,6 +24,7 @@
   export let ssrAnimeData: any = null;
   export let ssrCharactersData: any = null;
   export let ssrError: any = null;
+  export let streamingEnabled: boolean = false;
 
   let imageSources: string[] = [];
   let bgLoaded = false;
@@ -698,7 +699,7 @@
               </div>
             {/if}
           </div>
-          <StreamingPlatforms platforms={anime.streamingPlatforms} />
+          <StreamingPlatforms platforms={anime.streamingPlatforms} enabled={streamingEnabled} />
         </section>
       </div>
 

--- a/src/svelte/components/ShowContentWithProvider.svelte
+++ b/src/svelte/components/ShowContentWithProvider.svelte
@@ -7,11 +7,12 @@
   export let ssrAnimeData: any = null;
   export let ssrCharactersData: any = null;
   export let ssrError: any = null;
+  export let streamingEnabled: boolean = false;
 
   // Initialize query client
   const queryClient = initializeQueryClient();
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <ShowContent {animeId} {ssrAnimeData} {ssrCharactersData} {ssrError} />
+  <ShowContent {animeId} {ssrAnimeData} {ssrCharactersData} {ssrError} {streamingEnabled} />
 </QueryClientProvider>

--- a/src/svelte/components/StreamingPlatforms.svelte
+++ b/src/svelte/components/StreamingPlatforms.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { isFeatureEnabled, onFeatureFlags } from '../../utils/analytics';
-
   export let platforms: Array<{ platform: string; name?: string | null; url: string }> | null | undefined = undefined;
 
-  // PostHog loads flags asynchronously after init, so evaluating once at
-  // component creation races the flag load and gets stuck on `false`. Read it
-  // on mount and re-read whenever flags (re)load so the section appears once
-  // the flag resolves.
-  let featureEnabled = false;
-  onMount(() => {
-    featureEnabled = isFeatureEnabled('animeschedule-integration');
-    onFeatureFlags(() => {
-      featureEnabled = isFeatureEnabled('animeschedule-integration');
-    });
-  });
+  // The animeschedule-integration flag is evaluated server-side (see
+  // $lib/server/posthog) and passed in, so the section is part of the SSR HTML
+  // rather than depending on a client-only flag check that races hydration.
+  export let enabled: boolean = false;
 
   const platformIcons: Record<string, string> = {
     crunchyroll: 'https://img.animeschedule.net/production/assets/public/img/streams/crunchyroll.png',
@@ -36,7 +26,7 @@
   }
 </script>
 
-{#if featureEnabled && platforms && platforms.length > 0}
+{#if enabled && platforms && platforms.length > 0}
   <div class="streaming-platforms">
     <span class="label">Watch on</span>
     <div class="platforms-list">


### PR DESCRIPTION
## Problem
The streaming-platforms section is gated on the `animeschedule-integration` flag, but the show page is **server-rendered** and the gate was a **client-only** PostHog check. The client flag load races hydration, so even with the flag fully enabled (verified `isFeatureEnabled === true` in-browser) the section rendered nothing — the `{#if}` is false during SSR and the client update never took effect.

## Fix
Evaluate the flag **server-side** in the `load`, bake the result into the SSR HTML.

- **New reusable helper `$lib/server/posthog.ts`** — not just for this page:
  - `isFeatureEnabled(flagKey, config, cookies)` — single flag
  - `getFeatureFlags(keys[], config, cookies)` — several flags in one `/decide` call
  - Reuses the visitor's `distinct_id` from the `ph_<key>_posthog` cookie (stable rollout bucketing), sends `environment` as a person-property for env-scoped targeting, and defaults to `false` on any error.
  - Direct `fetch` to PostHog's `/decide` endpoint — **no `posthog-node` dependency** (avoids Cloudflare edge-runtime issues).
- `show/[id]/+page.server.ts` evaluates `animeschedule-integration` (in parallel with the existing GraphQL fetches — no added latency) and returns `streamingEnabled`.
- Threaded through `+page.svelte → ShowContentWithProvider → ShowContent → StreamingPlatforms`, which now gates on the server-provided `enabled` prop. Removed the client-only `onMount`/`onFeatureFlags` logic.

## Result
The "Watch on" section is part of the server-rendered HTML — no hydration/flag-race. Keeps env-scoped rollout control (staging vs production) via the `environment` person-property.

## Verified
`yarn check`: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)