### PR TITLE
fix: robust server-side PostHog flag eval in edge runtime

### DIFF
--- a/src/lib/server/posthog.ts
+++ b/src/lib/server/posthog.ts
@@ -20,20 +20,30 @@ type FlagMap = Record<string, boolean | string>;
 
 /**
  * Reuse the visitor's PostHog distinct_id (from the `ph_<key>_posthog` cookie)
- * so rollout bucketing stays consistent with the client; fall back to a random
- * id for anonymous requests.
+ * so rollout bucketing stays consistent with the client; fall back to an
+ * anonymous id otherwise.
+ *
+ * The cookie value is URL-encoded JSON, so it must be decoded before parsing.
+ * The fallback deliberately avoids `crypto.randomUUID()` — it isn't guaranteed
+ * in every edge runtime/compat-date, and throwing here would sink the whole
+ * flag lookup. The value only matters for percentage-rollout bucketing.
  */
 function distinctIdFrom(apiKey: string, cookies: Cookies): string {
-  const phCookie = cookies.get(`ph_${apiKey}_posthog`);
-  if (phCookie) {
+  const raw = cookies.get(`ph_${apiKey}_posthog`);
+  if (raw) {
     try {
-      const parsed = JSON.parse(phCookie);
+      const parsed = JSON.parse(decodeURIComponent(raw));
       if (parsed?.distinct_id) return parsed.distinct_id as string;
     } catch {
-      /* malformed cookie — fall through to a random id */
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed?.distinct_id) return parsed.distinct_id as string;
+      } catch {
+        /* malformed cookie — fall through to an anonymous id */
+      }
     }
   }
-  return crypto.randomUUID();
+  return `anon_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
 /** One `/decide` round-trip → the raw flag map (empty on missing key/error). */
@@ -65,7 +75,8 @@ export async function isFeatureEnabled(
   try {
     const flags = await decide(config, cookies);
     return !!flags[flagKey];
-  } catch {
+  } catch (err) {
+    console.warn(`[posthog] isFeatureEnabled(${flagKey}) failed:`, err);
     return false;
   }
 }


### PR DESCRIPTION
## Problem
After #73, the show page still didn't render the streaming section on prod. Verified live:
- PostHog `/decide` returns `animeschedule-integration: true` (from the browser) ✅
- but the SSR loader computed `streamingEnabled: false` ❌ (and `cf-cache-status: DYNAMIC`, so not a cache) — the **server-side** eval was throwing and being caught → false.

## Root cause
Two hazards in the `distinct_id` path of the server helper, both in the Cloudflare Workers runtime:
1. **`crypto.randomUUID()`** isn't guaranteed across Workers compat-dates. When the visitor has no PostHog cookie (or the cookie can't be parsed), the fallback called it — and if it throws, the whole flag lookup aborts to `false`.
2. The **`ph_<key>_posthog` cookie is URL-encoded JSON**, so `JSON.parse(raw)` throws without `decodeURIComponent` first — meaning we never read the real distinct_id and always hit the fragile fallback.

Since the flag is 100%-for-everyone, the distinct_id *value* is irrelevant to the result — only the throw mattered.

## Fix
- Drop `crypto.randomUUID()`; use a `Date`/`Math.random` anonymous id (value only affects %-rollout bucketing).
- `decodeURIComponent` the cookie before `JSON.parse` (with a raw fallback).
- Log eval failures server-side so future breakage shows in Cloudflare logs.

## Verified
`yarn check`: 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)