### PR TITLE
feat: serve a sitemap so Google can discover the catalogue

### DIFF
--- a/src/lib/server/sitemap.test.ts
+++ b/src/lib/server/sitemap.test.ts
@@ -1,0 +1,200 @@
+import {
+  ANIME_PER_SITEMAP,
+  chunkCount,
+  escapeXml,
+  getAnimeEntries,
+  getNewsEntries,
+  getSeasonEntries,
+  renderIndex,
+  renderUrlset,
+  toLastmod,
+  _clearSitemapCache
+} from './sitemap';
+
+beforeEach(() => _clearSitemapCache());
+
+/** Minimal stand-in for the graphql-request client. */
+function fakeClient(handler: (query: string, vars: any) => any) {
+  const calls: { query: string; vars: any }[] = [];
+  const client = {
+    request: jest.fn(async (query: string, vars: any) => {
+      calls.push({ query, vars });
+      return handler(query, vars);
+    })
+  };
+  return { client: client as any, calls };
+}
+
+describe('toLastmod', () => {
+  it('keeps the date from the API format, which is not ISO', () => {
+    expect(toLastmod('2026-08-03 04:25:32')).toBe('2026-08-03');
+  });
+
+  it('accepts an already-ISO value', () => {
+    expect(toLastmod('2026-08-03T04:25:32Z')).toBe('2026-08-03');
+  });
+
+  it('returns null for junk rather than emitting an invalid lastmod', () => {
+    expect(toLastmod('')).toBeNull();
+    expect(toLastmod(null)).toBeNull();
+    expect(toLastmod('not a date')).toBeNull();
+  });
+});
+
+describe('escapeXml', () => {
+  it('escapes the characters that would break a urlset', () => {
+    expect(escapeXml(`a&b<c>d"e'f`)).toBe('a&amp;b&lt;c&gt;d&quot;e&apos;f');
+  });
+});
+
+describe('chunkCount', () => {
+  it('never reports zero chunks, so the index always lists one', () => {
+    expect(chunkCount(0)).toBe(1);
+  });
+
+  it('splits on the page size boundary', () => {
+    expect(chunkCount(ANIME_PER_SITEMAP)).toBe(1);
+    expect(chunkCount(ANIME_PER_SITEMAP + 1)).toBe(2);
+    expect(chunkCount(31983)).toBe(4);
+  });
+});
+
+describe('renderUrlset', () => {
+  it('emits valid XML with lastmod only where known', () => {
+    const xml = renderUrlset([
+      { loc: 'https://weeb.vip/show/a', lastmod: '2026-08-03' },
+      { loc: 'https://weeb.vip/show/b', lastmod: null }
+    ]);
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('<loc>https://weeb.vip/show/a</loc>');
+    expect(xml).toContain('<lastmod>2026-08-03</lastmod>');
+    // Exactly one lastmod: the entry without a date must not emit an empty tag.
+    expect(xml.match(/<lastmod>/g)).toHaveLength(1);
+  });
+});
+
+describe('renderIndex', () => {
+  it('emits a sitemapindex, not a urlset', () => {
+    const xml = renderIndex([{ loc: 'https://weeb.vip/sitemap-anime-1.xml' }]);
+    expect(xml).toContain('<sitemapindex');
+    expect(xml).toContain('<sitemap>');
+    expect(xml).not.toContain('<urlset');
+  });
+});
+
+describe('getAnimeEntries', () => {
+  it('maps the catalogue onto show URLs with lastmod', async () => {
+    const { client } = fakeClient(() => ({
+      newestAnime: [
+        { id: 'a1', updatedAt: '2026-08-03 04:25:32' },
+        { id: 'a2', updatedAt: null }
+      ]
+    }));
+
+    const entries = await getAnimeEntries(client);
+
+    expect(entries).toEqual([
+      { loc: 'https://weeb.vip/show/a1', lastmod: '2026-08-03' },
+      { loc: 'https://weeb.vip/show/a2', lastmod: null }
+    ]);
+  });
+
+  it('drops entries with no id rather than emitting /show/undefined', async () => {
+    const { client } = fakeClient(() => ({
+      newestAnime: [{ id: 'a1', updatedAt: null }, { id: null }, {}]
+    }));
+
+    expect(await getAnimeEntries(client)).toHaveLength(1);
+  });
+
+  it('caches: listing 32k anime is far too expensive to repeat per request', async () => {
+    const { client, calls } = fakeClient(() => ({ newestAnime: [{ id: 'a1' }] }));
+
+    await getAnimeEntries(client);
+    await getAnimeEntries(client);
+
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('getNewsEntries', () => {
+  it('pages through the feed, which caps at 100 per call', async () => {
+    const total = 250;
+    const { client, calls } = fakeClient((_q, vars) => {
+      const offset = vars.offset as number;
+      const count = Math.min(100, total - offset);
+      return {
+        latestNews: {
+          total,
+          items: Array.from({ length: count }, (_, i) => ({
+            animeId: `anime-${offset + i}`,
+            publishedDate: '2026-08-03'
+          }))
+        }
+      };
+    });
+
+    const entries = await getNewsEntries(client);
+
+    expect(calls).toHaveLength(3);
+    expect(entries).toHaveLength(total);
+  });
+
+  it('lists each anime once, not once per story', async () => {
+    const { client } = fakeClient(() => ({
+      latestNews: {
+        total: 3,
+        items: [
+          { animeId: 'same', publishedDate: '2026-08-03' },
+          { animeId: 'same', publishedDate: '2026-07-01' },
+          { animeId: 'other', publishedDate: '2026-06-01' }
+        ]
+      }
+    }));
+
+    const entries = await getNewsEntries(client);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.loc)).toEqual([
+      'https://weeb.vip/show/same/news',
+      'https://weeb.vip/show/other/news'
+    ]);
+    // Newest story wins as the page's lastmod.
+    expect(entries[0].lastmod).toBe('2026-08-03');
+  });
+
+  it('stops when a page comes back empty, even if total disagrees', async () => {
+    const { client, calls } = fakeClient(() => ({
+      latestNews: { total: 9999, items: [] }
+    }));
+
+    expect(await getNewsEntries(client)).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('getSeasonEntries', () => {
+  it('lists only seasons that actually have anime', async () => {
+    const { client } = fakeClient((_q, vars) =>
+      vars.season === 'SUMMER_2026'
+        ? { animeBySeasons: [{ id: 'a' }] }
+        : { animeBySeasons: [] }
+    );
+
+    const entries = await getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'));
+
+    expect(entries).toEqual([{ loc: 'https://weeb.vip/season/SUMMER_2026' }]);
+  });
+
+  it('treats a failing season lookup as absent rather than throwing', async () => {
+    const { client } = fakeClient((_q, vars) => {
+      if (vars.season === 'WINTER_2026') throw new Error('boom');
+      return { animeBySeasons: [] };
+    });
+
+    await expect(
+      getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'))
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/lib/server/sitemap.ts
+++ b/src/lib/server/sitemap.ts
@@ -1,0 +1,228 @@
+import { createSSRGraphQLClient } from './ssr-graphql';
+
+// Sitemap data and XML assembly.
+//
+// The catalogue is ~32,000 anime, which is why this is a sitemap *index* rather than
+// one file: Google caps a single sitemap at 50,000 URLs, and show pages plus news
+// pages would crowd that ceiling. Chunking also keeps each response small enough to
+// generate and cache comfortably.
+//
+// Everything here is cached in module scope. Building a chunk means listing the whole
+// catalogue, and that is far too expensive to repeat per crawler request.
+
+export const SITE_URL = 'https://weeb.vip';
+export const ANIME_PER_SITEMAP = 10_000;
+
+// Long, because the catalogue moves slowly and the query is expensive. The CDN
+// cache in front of it is shorter, so a stale sitemap is never served for long.
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+export interface SitemapEntry {
+  loc: string;
+  lastmod?: string | null;
+}
+
+interface Cached<T> {
+  value: T;
+  expires: number;
+}
+
+let animeCache: Cached<SitemapEntry[]> | null = null;
+let newsCache: Cached<SitemapEntry[]> | null = null;
+
+/**
+ * The API returns "2026-08-03 04:25:32" — not ISO 8601, and with no zone marker.
+ * Rather than guess at a timezone and risk advertising a lastmod that is a day out,
+ * this keeps the date only. A bare YYYY-MM-DD is valid W3C datetime, which is all
+ * the sitemap spec asks for, and it is honest about the precision we actually have.
+ */
+export function toLastmod(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(raw.trim());
+  return match ? match[1] : null;
+}
+
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function renderUrlset(entries: SitemapEntry[]): string {
+  const urls = entries
+    .map(({ loc, lastmod }) => {
+      const parts = [`    <loc>${escapeXml(loc)}</loc>`];
+      if (lastmod) parts.push(`    <lastmod>${lastmod}</lastmod>`);
+      return `  <url>\n${parts.join('\n')}\n  </url>`;
+    })
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+function renderIndex(entries: SitemapEntry[]): string {
+  const maps = entries
+    .map(({ loc, lastmod }) => {
+      const parts = [`    <loc>${escapeXml(loc)}</loc>`];
+      if (lastmod) parts.push(`    <lastmod>${lastmod}</lastmod>`);
+      return `  <sitemap>\n${parts.join('\n')}\n  </sitemap>`;
+    })
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${maps}\n</sitemapindex>\n`;
+}
+
+export { renderUrlset, renderIndex };
+
+const ALL_ANIME_QUERY = `
+  query SitemapAnime($limit: Int!) {
+    newestAnime(limit: $limit) {
+      id
+      updatedAt
+    }
+  }
+`;
+
+const NEWS_PAGE_QUERY = `
+  query SitemapNews($limit: Int!, $offset: Int!) {
+    latestNews(limit: $limit, offset: $offset) {
+      total
+      items {
+        animeId
+        publishedDate
+      }
+    }
+  }
+`;
+
+// newestAnime has no pagination, only a limit, so this asks for more than the
+// catalogue holds and takes what comes back. Revisit if the catalogue approaches it.
+const CATALOGUE_CEILING = 100_000;
+
+// latestNews caps its page size at 100 regardless of what is requested.
+const NEWS_PAGE_SIZE = 100;
+
+// Guards the offset loop against an API that keeps reporting a total it will not serve.
+const MAX_NEWS_PAGES = 200;
+
+type Client = ReturnType<typeof createSSRGraphQLClient>;
+
+export async function getAnimeEntries(client: Client): Promise<SitemapEntry[]> {
+  if (animeCache && animeCache.expires > Date.now()) return animeCache.value;
+
+  const res: any = await client.request(ALL_ANIME_QUERY, { limit: CATALOGUE_CEILING });
+  const entries: SitemapEntry[] = (res?.newestAnime ?? [])
+    .filter((a: any) => a?.id)
+    .map((a: any) => ({
+      loc: `${SITE_URL}/show/${a.id}`,
+      lastmod: toLastmod(a.updatedAt)
+    }));
+
+  animeCache = { value: entries, expires: Date.now() + TTL_MS };
+  return entries;
+}
+
+/**
+ * News hub pages, for anime that actually have news.
+ *
+ * Deliberately not one per anime: /show/<id>/news exists for all ~32,000, but for the
+ * vast majority it renders nothing. Submitting 32,000 empty pages is how a site earns
+ * a thin-content reputation, so only anime with at least one story are listed.
+ */
+export async function getNewsEntries(client: Client): Promise<SitemapEntry[]> {
+  if (newsCache && newsCache.expires > Date.now()) return newsCache.value;
+
+  const newest = new Map<string, string | null>();
+  let offset = 0;
+  let total = Infinity;
+  let pages = 0;
+
+  while (offset < total && pages < MAX_NEWS_PAGES) {
+    const res: any = await client.request(NEWS_PAGE_QUERY, {
+      limit: NEWS_PAGE_SIZE,
+      offset
+    });
+    const feed = res?.latestNews;
+    const items: any[] = feed?.items ?? [];
+    total = typeof feed?.total === 'number' ? feed.total : 0;
+
+    for (const item of items) {
+      if (!item?.animeId) continue;
+      const lastmod = toLastmod(item.publishedDate);
+      const current = newest.get(item.animeId);
+      // The feed is newest-first, so the first date seen for an anime is its latest.
+      if (current === undefined || (lastmod && current && lastmod > current)) {
+        newest.set(item.animeId, lastmod ?? current ?? null);
+      }
+    }
+
+    if (!items.length) break;
+    offset += items.length;
+    pages += 1;
+  }
+
+  const entries: SitemapEntry[] = [...newest.entries()].map(([id, lastmod]) => ({
+    loc: `${SITE_URL}/show/${id}/news`,
+    lastmod
+  }));
+
+  newsCache = { value: entries, expires: Date.now() + TTL_MS };
+  return entries;
+}
+
+/**
+ * Season pages, discovered rather than hardcoded: the API only holds a couple of
+ * years, and a hardcoded list would either go stale or advertise empty pages.
+ */
+export async function getSeasonEntries(client: Client, now: Date): Promise<SitemapEntry[]> {
+  const year = now.getUTCFullYear();
+  const seasons = ['WINTER', 'SPRING', 'SUMMER', 'FALL'];
+  const candidates: string[] = [];
+  for (const y of [year - 1, year, year + 1]) {
+    for (const s of seasons) candidates.push(`${s}_${y}`);
+  }
+
+  const checked = await Promise.all(
+    candidates.map(async (season) => {
+      try {
+        // `Season` is a custom scalar, not String — declaring $season as String!
+        // fails validation and every season silently looks empty.
+        const res: any = await client.request(
+          `query SitemapSeason($season: Season!) { animeBySeasons(season: $season, limit: 1) { id } }`,
+          { season }
+        );
+        return (res?.animeBySeasons ?? []).length > 0 ? season : null;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return checked
+    .filter((s): s is string => Boolean(s))
+    .map((season) => ({ loc: `${SITE_URL}/season/${season}` }));
+}
+
+/** Static pages worth indexing. Auth, profile and settings are deliberately absent. */
+export const STATIC_PATHS = ['/', '/airing', '/airing/calendar', '/about'];
+
+export function chunkCount(total: number): number {
+  return Math.max(1, Math.ceil(total / ANIME_PER_SITEMAP));
+}
+
+export function xmlResponse(body: string): Response {
+  return new Response(body, {
+    headers: {
+      'content-type': 'application/xml; charset=utf-8',
+      // Crawlers refetch sitemaps often; let the CDN carry that load.
+      'cache-control': 'public, max-age=3600, s-maxage=21600'
+    }
+  });
+}
+
+/** Exposed for tests. */
+export function _clearSitemapCache(): void {
+  animeCache = null;
+  newsCache = null;
+}

--- a/src/routes/sitemap-anime-[page].xml/+server.ts
+++ b/src/routes/sitemap-anime-[page].xml/+server.ts
@@ -1,0 +1,26 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
+import {
+  ANIME_PER_SITEMAP,
+  chunkCount,
+  getAnimeEntries,
+  renderUrlset,
+  xmlResponse
+} from '$lib/server/sitemap';
+
+/** One chunk of show pages. Chunk numbers are 1-based, as listed in the index. */
+export const GET: RequestHandler = async ({ params, locals }) => {
+  const page = Number(params.page);
+  if (!Number.isInteger(page) || page < 1) error(404, 'Not found');
+
+  const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+  const anime = await getAnimeEntries(client);
+
+  // 404 rather than an empty urlset: a chunk beyond the end is a stale index entry,
+  // and Search Console should surface that instead of silently reporting zero URLs.
+  if (page > chunkCount(anime.length)) error(404, 'Not found');
+
+  const start = (page - 1) * ANIME_PER_SITEMAP;
+  return xmlResponse(renderUrlset(anime.slice(start, start + ANIME_PER_SITEMAP)));
+};

--- a/src/routes/sitemap-news.xml/+server.ts
+++ b/src/routes/sitemap-news.xml/+server.ts
@@ -1,0 +1,15 @@
+import type { RequestHandler } from './$types';
+import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
+import { getNewsEntries, renderUrlset, xmlResponse } from '$lib/server/sitemap';
+
+/**
+ * News hub pages, for anime that actually have news.
+ *
+ * Note this lists /show/<id>/news, not individual stories — they have no URLs of
+ * their own yet. Per-article routes are what would let Google rank individual
+ * stories; until they exist this is the finest granularity available.
+ */
+export const GET: RequestHandler = async ({ locals }) => {
+  const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+  return xmlResponse(renderUrlset(await getNewsEntries(client)));
+};

--- a/src/routes/sitemap-pages.xml/+server.ts
+++ b/src/routes/sitemap-pages.xml/+server.ts
@@ -1,0 +1,29 @@
+import type { RequestHandler } from './$types';
+import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
+import {
+  SITE_URL,
+  STATIC_PATHS,
+  getSeasonEntries,
+  renderUrlset,
+  xmlResponse
+} from '$lib/server/sitemap';
+
+/** Static pages plus the season pages that actually have anime behind them. */
+export const GET: RequestHandler = async ({ locals }) => {
+  const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+
+  const statics = STATIC_PATHS.map((path) => ({
+    loc: path === '/' ? `${SITE_URL}/` : `${SITE_URL}${path}`
+  }));
+
+  let seasons: { loc: string }[] = [];
+  try {
+    seasons = await getSeasonEntries(client, new Date());
+  } catch (e) {
+    // A season lookup failure should not take out the whole sitemap — the static
+    // pages are still worth serving.
+    console.error('[sitemap] season discovery failed:', e);
+  }
+
+  return xmlResponse(renderUrlset([...statics, ...seasons]));
+};

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from './$types';
+import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
+import {
+  SITE_URL,
+  chunkCount,
+  getAnimeEntries,
+  renderIndex,
+  xmlResponse
+} from '$lib/server/sitemap';
+
+/**
+ * Sitemap index. The catalogue is ~32,000 anime, past what belongs in a single file
+ * once news pages are counted, so the show pages are split into chunks and listed here.
+ *
+ * Submit this URL to Search Console; the children are discovered from it.
+ */
+export const GET: RequestHandler = async ({ locals }) => {
+  const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+  const anime = await getAnimeEntries(client);
+
+  const children = [
+    { loc: `${SITE_URL}/sitemap-pages.xml` },
+    ...Array.from({ length: chunkCount(anime.length) }, (_, i) => ({
+      loc: `${SITE_URL}/sitemap-anime-${i + 1}.xml`
+    })),
+    { loc: `${SITE_URL}/sitemap-news.xml` }
+  ];
+
+  return xmlResponse(renderIndex(children));
+};


### PR DESCRIPTION
`robots.txt` has advertised `Sitemap: https://weeb.vip/sitemap.xml` since it was written — and that URL has always returned **404**. Google has had no discovery path to the ~32,000 show pages beyond following internal links.

## Shape

A sitemap *index*, not a single file: 31,983 anime plus news pages crowds the 50,000-URL cap Google places on one sitemap, and chunking keeps each response cheap to build and cache.

| URL | Contents | Count |
|---|---|---|
| `/sitemap.xml` | index | 6 children |
| `/sitemap-pages.xml` | static pages + seasons with anime | 11 |
| `/sitemap-anime-{1..4}.xml` | show pages, 10,000/chunk | 31,983 |
| `/sitemap-news.xml` | `/show/<id>/news` | 122 |

`robots.txt` needs no change — it already points here.

## Decisions worth reviewing

**News pages are listed only for anime that actually have news** — 122 today, not 32,000. `/show/<id>/news` exists for every anime but renders nothing for almost all of them, and submitting 32,000 empty pages is how a site earns a thin-content reputation.

**`lastmod` carries the date only.** The API returns `2026-08-03 04:25:32` — neither ISO 8601 nor zone-annotated. Guessing a timezone risks advertising a modification date that's a day out (the same class of bug that shifted `published_date` in news-ingest). A bare `YYYY-MM-DD` is valid W3C datetime and honest about the precision we have.

**Seasons are discovered, not hardcoded**, so the list follows the data instead of going stale. `SPRING_2025` is correctly absent — no anime behind it.

**A chunk beyond the end 404s** rather than returning an empty `urlset`, so a stale index entry surfaces in Search Console instead of silently reporting zero URLs.

Everything is cached in module scope for six hours, with a shorter CDN cache in front — building a chunk means listing the whole catalogue.

## A gotcha for the next person

`animeBySeasons` takes the custom scalar `Season`, **not** `String`. Declaring the variable as `String!` fails validation, and because the failure is per-season and caught, every season silently looks empty. That cost me a build cycle; there's a comment on it now.

## Verification

98 tests pass (16 new, covering lastmod parsing, XML escaping, chunk boundaries, dedup, feed pagination, and season discovery).

Against a production build hitting the real API, all responses parse as valid XML via `ElementTree`:

```
OK  /sitemap.xml            <sitemapindex> entries=6      0.00 MB
OK  /sitemap-pages.xml      <urlset> entries=11           0.00 MB
OK  /sitemap-anime-1.xml    <urlset> entries=10000  lastmod=10000  1.19 MB
OK  /sitemap-anime-4.xml    <urlset> entries=1983   lastmod=1983   0.24 MB
OK  /sitemap-news.xml       <urlset> entries=122    lastmod=121    0.02 MB
sitemap-anime-5.xml -> HTTP 404
```

Well inside Google's 50,000-URL and 50MB per-file limits.

## Follow-up

Submit `/sitemap.xml` in Search Console once merged — robots.txt discovery works but explicit submission gets it crawled sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
