### PR TITLE
fix: build absolute URLs from the requesting origin

### DIFF
--- a/src/lib/Seo.svelte
+++ b/src/lib/Seo.svelte
@@ -13,7 +13,12 @@
 
   $: pageTitle = title ? `${title} | WeebVIP` : defaultTitle;
   $: pageDescription = description || defaultDescription;
-  $: pageImage = new URL(image || defaultImage, siteUrl).toString();
+  // Resolved against the host that actually served this page, not the canonical site.
+  // og:image has to be fetchable: on staging, resolving against siteUrl pointed the tag
+  // at https://weeb.vip/og/<id>, which is a different deployment and 404s there.
+  $: pageImage = new URL(image || defaultImage, $page.url.origin).toString();
+  // canonical, og:url and twitter:url deliberately stay on the canonical host. Staging
+  // self-canonicalising would make it an indexable duplicate of production.
   $: canonicalUrl = new URL($page.url.pathname, siteUrl).toString();
 </script>
 

--- a/src/lib/server/sitemap.test.ts
+++ b/src/lib/server/sitemap.test.ts
@@ -2,8 +2,10 @@ import {
   ANIME_PER_SITEMAP,
   chunkCount,
   escapeXml,
-  getAnimeEntries,
-  getNewsEntries,
+  animeEntries,
+  getAnimeRecords,
+  getNewsRecords,
+  newsEntries,
   getSeasonEntries,
   renderIndex,
   renderUrlset,
@@ -11,7 +13,46 @@ import {
   _clearSitemapCache
 } from './sitemap';
 
+const SITE = 'https://weeb.vip';
+const STAGING = 'https://staging.weeb.vip';
+
 beforeEach(() => _clearSitemapCache());
+
+describe('per-origin URLs', () => {
+  it('builds show URLs on whichever origin asked', () => {
+    const records = [{ id: 'a1', lastmod: '2026-08-03' }];
+
+    expect(animeEntries(records, SITE)[0].loc).toBe('https://weeb.vip/show/a1');
+    // A sitemap served from staging must not send crawlers to production.
+    expect(animeEntries(records, STAGING)[0].loc).toBe('https://staging.weeb.vip/show/a1');
+  });
+
+  it('builds news URLs on whichever origin asked', () => {
+    const records = [{ id: 'a1', lastmod: null }];
+
+    expect(newsEntries(records, STAGING)[0].loc).toBe('https://staging.weeb.vip/show/a1/news');
+  });
+
+  it('carries lastmod through unchanged', () => {
+    const records = [{ id: 'a1', lastmod: '2026-08-03' }];
+
+    expect(animeEntries(records, SITE)[0].lastmod).toBe('2026-08-03');
+    expect(newsEntries(records, SITE)[0].lastmod).toBe('2026-08-03');
+  });
+
+  it('caches records, not URLs, so a staging request cannot poison production', async () => {
+    const { client, calls } = fakeClient(() => ({
+      newestAnime: [{ id: 'a1', updatedAt: null }]
+    }));
+
+    const first = animeEntries(await getAnimeRecords(client), STAGING);
+    const second = animeEntries(await getAnimeRecords(client), SITE);
+
+    expect(calls).toHaveLength(1); // second call served from cache
+    expect(first[0].loc).toBe('https://staging.weeb.vip/show/a1');
+    expect(second[0].loc).toBe('https://weeb.vip/show/a1');
+  });
+});
 
 /** Minimal stand-in for the graphql-request client. */
 function fakeClient(handler: (query: string, vars: any) => any) {
@@ -92,11 +133,12 @@ describe('getAnimeEntries', () => {
       ]
     }));
 
-    const entries = await getAnimeEntries(client);
+    const records = await getAnimeRecords(client);
 
-    expect(entries).toEqual([
-      { loc: 'https://weeb.vip/show/a1', lastmod: '2026-08-03' },
-      { loc: 'https://weeb.vip/show/a2', lastmod: null }
+    // Records are host-independent; the URL is built later, per request origin.
+    expect(records).toEqual([
+      { id: 'a1', lastmod: '2026-08-03' },
+      { id: 'a2', lastmod: null }
     ]);
   });
 
@@ -105,14 +147,14 @@ describe('getAnimeEntries', () => {
       newestAnime: [{ id: 'a1', updatedAt: null }, { id: null }, {}]
     }));
 
-    expect(await getAnimeEntries(client)).toHaveLength(1);
+    expect(await getAnimeRecords(client)).toHaveLength(1);
   });
 
   it('caches: listing 32k anime is far too expensive to repeat per request', async () => {
     const { client, calls } = fakeClient(() => ({ newestAnime: [{ id: 'a1' }] }));
 
-    await getAnimeEntries(client);
-    await getAnimeEntries(client);
+    await getAnimeRecords(client);
+    await getAnimeRecords(client);
 
     expect(calls).toHaveLength(1);
   });
@@ -135,7 +177,7 @@ describe('getNewsEntries', () => {
       };
     });
 
-    const entries = await getNewsEntries(client);
+    const entries = await getNewsRecords(client);
 
     expect(calls).toHaveLength(3);
     expect(entries).toHaveLength(total);
@@ -153,7 +195,7 @@ describe('getNewsEntries', () => {
       }
     }));
 
-    const entries = await getNewsEntries(client);
+    const entries = newsEntries(await getNewsRecords(client), SITE);
 
     expect(entries).toHaveLength(2);
     expect(entries.map((e) => e.loc)).toEqual([
@@ -169,7 +211,7 @@ describe('getNewsEntries', () => {
       latestNews: { total: 9999, items: [] }
     }));
 
-    expect(await getNewsEntries(client)).toEqual([]);
+    expect(await getNewsRecords(client)).toEqual([]);
     expect(calls).toHaveLength(1);
   });
 });
@@ -182,7 +224,7 @@ describe('getSeasonEntries', () => {
         : { animeBySeasons: [] }
     );
 
-    const entries = await getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'));
+    const entries = await getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'), SITE);
 
     expect(entries).toEqual([{ loc: 'https://weeb.vip/season/SUMMER_2026' }]);
   });
@@ -194,7 +236,7 @@ describe('getSeasonEntries', () => {
     });
 
     await expect(
-      getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'))
+      getSeasonEntries(client, new Date('2026-08-03T00:00:00Z'), SITE)
     ).resolves.toEqual([]);
   });
 });

--- a/src/lib/server/sitemap.ts
+++ b/src/lib/server/sitemap.ts
@@ -10,7 +10,9 @@ import { createSSRGraphQLClient } from './ssr-graphql';
 // Everything here is cached in module scope. Building a chunk means listing the whole
 // catalogue, and that is far too expensive to repeat per crawler request.
 
-export const SITE_URL = 'https://weeb.vip';
+// URLs are built from the origin that served the request, never a hardcoded host: a
+// sitemap served from staging must advertise staging URLs, or it points crawlers at a
+// different deployment entirely.
 export const ANIME_PER_SITEMAP = 10_000;
 
 // Long, because the catalogue moves slowly and the query is expensive. The CDN
@@ -27,8 +29,17 @@ interface Cached<T> {
   expires: number;
 }
 
-let animeCache: Cached<SitemapEntry[]> | null = null;
-let newsCache: Cached<SitemapEntry[]> | null = null;
+/**
+ * Cached shape is host-independent — an id and a date, not a URL. Caching finished
+ * URLs would key the whole catalogue to whichever origin happened to warm the cache.
+ */
+export interface SitemapRecord {
+  id: string;
+  lastmod: string | null;
+}
+
+let animeCache: Cached<SitemapRecord[]> | null = null;
+let newsCache: Cached<SitemapRecord[]> | null = null;
 
 /**
  * The API returns "2026-08-03 04:25:32" — not ISO 8601, and with no zone marker.
@@ -108,19 +119,20 @@ const MAX_NEWS_PAGES = 200;
 
 type Client = ReturnType<typeof createSSRGraphQLClient>;
 
-export async function getAnimeEntries(client: Client): Promise<SitemapEntry[]> {
+export async function getAnimeRecords(client: Client): Promise<SitemapRecord[]> {
   if (animeCache && animeCache.expires > Date.now()) return animeCache.value;
 
   const res: any = await client.request(ALL_ANIME_QUERY, { limit: CATALOGUE_CEILING });
-  const entries: SitemapEntry[] = (res?.newestAnime ?? [])
+  const records: SitemapRecord[] = (res?.newestAnime ?? [])
     .filter((a: any) => a?.id)
-    .map((a: any) => ({
-      loc: `${SITE_URL}/show/${a.id}`,
-      lastmod: toLastmod(a.updatedAt)
-    }));
+    .map((a: any) => ({ id: a.id, lastmod: toLastmod(a.updatedAt) }));
 
-  animeCache = { value: entries, expires: Date.now() + TTL_MS };
-  return entries;
+  animeCache = { value: records, expires: Date.now() + TTL_MS };
+  return records;
+}
+
+export function animeEntries(records: SitemapRecord[], siteUrl: string): SitemapEntry[] {
+  return records.map(({ id, lastmod }) => ({ loc: `${siteUrl}/show/${id}`, lastmod }));
 }
 
 /**
@@ -130,7 +142,7 @@ export async function getAnimeEntries(client: Client): Promise<SitemapEntry[]> {
  * vast majority it renders nothing. Submitting 32,000 empty pages is how a site earns
  * a thin-content reputation, so only anime with at least one story are listed.
  */
-export async function getNewsEntries(client: Client): Promise<SitemapEntry[]> {
+export async function getNewsRecords(client: Client): Promise<SitemapRecord[]> {
   if (newsCache && newsCache.expires > Date.now()) return newsCache.value;
 
   const newest = new Map<string, string | null>();
@@ -162,20 +174,28 @@ export async function getNewsEntries(client: Client): Promise<SitemapEntry[]> {
     pages += 1;
   }
 
-  const entries: SitemapEntry[] = [...newest.entries()].map(([id, lastmod]) => ({
-    loc: `${SITE_URL}/show/${id}/news`,
+  const records: SitemapRecord[] = [...newest.entries()].map(([id, lastmod]) => ({
+    id,
     lastmod
   }));
 
-  newsCache = { value: entries, expires: Date.now() + TTL_MS };
-  return entries;
+  newsCache = { value: records, expires: Date.now() + TTL_MS };
+  return records;
+}
+
+export function newsEntries(records: SitemapRecord[], siteUrl: string): SitemapEntry[] {
+  return records.map(({ id, lastmod }) => ({ loc: `${siteUrl}/show/${id}/news`, lastmod }));
 }
 
 /**
  * Season pages, discovered rather than hardcoded: the API only holds a couple of
  * years, and a hardcoded list would either go stale or advertise empty pages.
  */
-export async function getSeasonEntries(client: Client, now: Date): Promise<SitemapEntry[]> {
+export async function getSeasonEntries(
+  client: Client,
+  now: Date,
+  siteUrl: string
+): Promise<SitemapEntry[]> {
   const year = now.getUTCFullYear();
   const seasons = ['WINTER', 'SPRING', 'SUMMER', 'FALL'];
   const candidates: string[] = [];
@@ -201,7 +221,7 @@ export async function getSeasonEntries(client: Client, now: Date): Promise<Sitem
 
   return checked
     .filter((s): s is string => Boolean(s))
-    .map((season) => ({ loc: `${SITE_URL}/season/${season}` }));
+    .map((season) => ({ loc: `${siteUrl}/season/${season}` }));
 }
 
 /** Static pages worth indexing. Auth, profile and settings are deliberately absent. */

--- a/src/routes/sitemap-anime-[page].xml/+server.ts
+++ b/src/routes/sitemap-anime-[page].xml/+server.ts
@@ -3,24 +3,26 @@ import type { RequestHandler } from './$types';
 import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
 import {
   ANIME_PER_SITEMAP,
+  animeEntries,
   chunkCount,
-  getAnimeEntries,
+  getAnimeRecords,
   renderUrlset,
   xmlResponse
 } from '$lib/server/sitemap';
 
 /** One chunk of show pages. Chunk numbers are 1-based, as listed in the index. */
-export const GET: RequestHandler = async ({ params, locals }) => {
+export const GET: RequestHandler = async ({ params, locals, url }) => {
   const page = Number(params.page);
   if (!Number.isInteger(page) || page < 1) error(404, 'Not found');
 
   const client = createSSRGraphQLClient(locals.config.graphql_host, null);
-  const anime = await getAnimeEntries(client);
+  const anime = await getAnimeRecords(client);
 
   // 404 rather than an empty urlset: a chunk beyond the end is a stale index entry,
   // and Search Console should surface that instead of silently reporting zero URLs.
   if (page > chunkCount(anime.length)) error(404, 'Not found');
 
   const start = (page - 1) * ANIME_PER_SITEMAP;
-  return xmlResponse(renderUrlset(anime.slice(start, start + ANIME_PER_SITEMAP)));
+  const slice = anime.slice(start, start + ANIME_PER_SITEMAP);
+  return xmlResponse(renderUrlset(animeEntries(slice, url.origin)));
 };

--- a/src/routes/sitemap-news.xml/+server.ts
+++ b/src/routes/sitemap-news.xml/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from './$types';
 import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
-import { getNewsEntries, renderUrlset, xmlResponse } from '$lib/server/sitemap';
+import { getNewsRecords, newsEntries, renderUrlset, xmlResponse } from '$lib/server/sitemap';
 
 /**
  * News hub pages, for anime that actually have news.
@@ -9,7 +9,8 @@ import { getNewsEntries, renderUrlset, xmlResponse } from '$lib/server/sitemap';
  * their own yet. Per-article routes are what would let Google rank individual
  * stories; until they exist this is the finest granularity available.
  */
-export const GET: RequestHandler = async ({ locals }) => {
+export const GET: RequestHandler = async ({ locals, url }) => {
   const client = createSSRGraphQLClient(locals.config.graphql_host, null);
-  return xmlResponse(renderUrlset(await getNewsEntries(client)));
+  const records = await getNewsRecords(client);
+  return xmlResponse(renderUrlset(newsEntries(records, url.origin)));
 };

--- a/src/routes/sitemap-pages.xml/+server.ts
+++ b/src/routes/sitemap-pages.xml/+server.ts
@@ -1,24 +1,19 @@
 import type { RequestHandler } from './$types';
 import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
-import {
-  SITE_URL,
-  STATIC_PATHS,
-  getSeasonEntries,
-  renderUrlset,
-  xmlResponse
-} from '$lib/server/sitemap';
+import { STATIC_PATHS, getSeasonEntries, renderUrlset, xmlResponse } from '$lib/server/sitemap';
 
 /** Static pages plus the season pages that actually have anime behind them. */
-export const GET: RequestHandler = async ({ locals }) => {
+export const GET: RequestHandler = async ({ locals, url }) => {
   const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+  const site = url.origin;
 
   const statics = STATIC_PATHS.map((path) => ({
-    loc: path === '/' ? `${SITE_URL}/` : `${SITE_URL}${path}`
+    loc: path === '/' ? `${site}/` : `${site}${path}`
   }));
 
   let seasons: { loc: string }[] = [];
   try {
-    seasons = await getSeasonEntries(client, new Date());
+    seasons = await getSeasonEntries(client, new Date(), site);
   } catch (e) {
     // A season lookup failure should not take out the whole sitemap — the static
     // pages are still worth serving.

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,29 +1,27 @@
 import type { RequestHandler } from './$types';
 import { createSSRGraphQLClient } from '$lib/server/ssr-graphql';
-import {
-  SITE_URL,
-  chunkCount,
-  getAnimeEntries,
-  renderIndex,
-  xmlResponse
-} from '$lib/server/sitemap';
+import { chunkCount, getAnimeRecords, renderIndex, xmlResponse } from '$lib/server/sitemap';
 
 /**
  * Sitemap index. The catalogue is ~32,000 anime, past what belongs in a single file
  * once news pages are counted, so the show pages are split into chunks and listed here.
  *
+ * Children are addressed on the requesting origin, so a sitemap fetched from staging
+ * points at staging rather than sending crawlers to production.
+ *
  * Submit this URL to Search Console; the children are discovered from it.
  */
-export const GET: RequestHandler = async ({ locals }) => {
+export const GET: RequestHandler = async ({ locals, url }) => {
   const client = createSSRGraphQLClient(locals.config.graphql_host, null);
-  const anime = await getAnimeEntries(client);
+  const anime = await getAnimeRecords(client);
+  const site = url.origin;
 
   const children = [
-    { loc: `${SITE_URL}/sitemap-pages.xml` },
+    { loc: `${site}/sitemap-pages.xml` },
     ...Array.from({ length: chunkCount(anime.length) }, (_, i) => ({
-      loc: `${SITE_URL}/sitemap-anime-${i + 1}.xml`
+      loc: `${site}/sitemap-anime-${i + 1}.xml`
     })),
-    { loc: `${SITE_URL}/sitemap-news.xml` }
+    { loc: `${site}/sitemap-news.xml` }
   ];
 
   return xmlResponse(renderIndex(children));


### PR DESCRIPTION
On staging, `og:image` resolved to `https://weeb.vip/og/<id>` — a different deployment, which 404s there. The image was never going to load on any host but production.

## Cause

`Seo.svelte` resolves every relative URL against a hardcoded constant:

```ts
const siteUrl = 'https://weeb.vip';
$: pageImage = new URL(image || defaultImage, siteUrl).toString();
```

So a page served from `staging.weeb.vip` advertised a production image URL.

## Fix

`og:image` and `twitter:image` now resolve against the host that served the page.

**`canonical`, `og:url` and `twitter:url` deliberately stay on the canonical host.** Staging self-canonicalising would make it an indexable duplicate of production, which is worse than a share card linking to prod. Only the image — the thing that has to actually be *fetchable* — follows the request.

## The sitemap had it worse

Same bug, bigger consequence: a sitemap served from staging advertised **production** URLs, pointing crawlers at another deployment entirely. All sitemap URLs now come from the request origin.

That meant splitting caching from rendering. The cached shape is now `{ id, lastmod }` rather than a finished URL:

```ts
export interface SitemapRecord {
  id: string;
  lastmod: string | null;
}
```

Caching finished URLs would key the whole catalogue to whichever origin warmed the cache first — one staging request and production would serve a sitemap full of `staging.weeb.vip` links for the next six hours. There's a test pinning that.

## Verification

118 tests pass (4 new, covering per-origin URL building and the cache-poisoning case).

Same production build, served under two `Host` headers:

```
Host: staging.weeb.vip
  og:image     https://staging.weeb.vip/og/bd4134c1-...
  twitter:image https://staging.weeb.vip/og/bd4134c1-...
  og:url       https://weeb.vip/show/bd4134c1-...      <- canonical, by design
  canonical    https://weeb.vip/show/bd4134c1-...      <- canonical, by design

Host: weeb.vip
  og:image     https://weeb.vip/og/bd4134c1-...

sitemap.xml       (staging) -> https://staging.weeb.vip/sitemap-anime-1.xml
sitemap-anime-1   (staging) -> https://staging.weeb.vip/show/8cebc7f4-...
sitemap-anime-1   (prod)    -> https://weeb.vip/show/8cebc7f4-...   <- same warm cache
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
