### PR TITLE
feat: return 404 for missing anime, and describe pages with schema.org

### DIFF
--- a/src/lib/StructuredData.svelte
+++ b/src/lib/StructuredData.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { serializeJsonLd } from './structured-data';
+
+  /** One schema object, or several to emit as separate blocks. Nulls are skipped. */
+  export let schemas: (Record<string, unknown> | null)[] = [];
+
+  $: present = schemas.filter((s): s is Record<string, unknown> => Boolean(s));
+</script>
+
+<svelte:head>
+  {#each present as schema}
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- serializeJsonLd escapes "<" -->
+    {@html `<script type="application/ld+json">${serializeJsonLd(schema)}<\/script>`}
+  {/each}
+</svelte:head>

--- a/src/lib/server/ssr-graphql.test.ts
+++ b/src/lib/server/ssr-graphql.test.ts
@@ -1,0 +1,63 @@
+import { isNotFoundError } from './ssr-graphql';
+
+/** The shape graphql-request throws for a missing anime, via the federation router. */
+const NOT_FOUND = {
+  message: "Failed to fetch from Subgraph 'anime-api'.",
+  response: {
+    errors: [
+      {
+        message: "Failed to fetch from Subgraph 'anime-api'.",
+        extensions: {
+          errors: [
+            {
+              message: 'record not found',
+              path: ['anime'],
+              extensions: { code: 'DOWNSTREAM_SERVICE_ERROR' }
+            }
+          ],
+          serviceName: 'anime-api'
+        }
+      }
+    ],
+    data: null
+  }
+};
+
+describe('isNotFoundError', () => {
+  it('recognises a missing record nested in subgraph extensions', () => {
+    expect(isNotFoundError(NOT_FOUND)).toBe(true);
+  });
+
+  it('recognises it at the top level too', () => {
+    expect(
+      isNotFoundError({ response: { errors: [{ message: 'record not found' }] } })
+    ).toBe(true);
+  });
+
+  it('does NOT treat a gateway failure as not-found', () => {
+    // The important negative: answering 404 for a transient outage would tell Google
+    // that real pages are gone.
+    expect(
+      isNotFoundError({
+        message: 'connect ECONNREFUSED',
+        response: {
+          errors: [{ message: "Failed to fetch from Subgraph 'anime-api'." }]
+        }
+      })
+    ).toBe(false);
+  });
+
+  it('does not treat auth or timeout errors as not-found', () => {
+    expect(isNotFoundError({ message: 'Request timeout' })).toBe(false);
+    expect(
+      isNotFoundError({ response: { errors: [{ message: 'access denied' }] } })
+    ).toBe(false);
+  });
+
+  it('survives malformed errors', () => {
+    expect(isNotFoundError(null)).toBe(false);
+    expect(isNotFoundError({})).toBe(false);
+    expect(isNotFoundError({ response: {} })).toBe(false);
+    expect(isNotFoundError({ response: { errors: [{ extensions: {} }] } })).toBe(false);
+  });
+});

--- a/src/lib/server/ssr-graphql.ts
+++ b/src/lib/server/ssr-graphql.ts
@@ -56,6 +56,31 @@ export function isAuthError(error: any): boolean {
          message.includes('expired');
 }
 
+/**
+ * True when the gateway is telling us the record does not exist, as opposed to
+ * failing to answer.
+ *
+ * The distinction matters for status codes: "no such anime" is a 404, while a gateway
+ * blip must not be, or Google would start dropping real pages from the index. The
+ * federation router reports it as a *thrown* error rather than a null field —
+ * a DOWNSTREAM_SERVICE_ERROR wrapping anime-api's "record not found" — so a plain
+ * `if (!data.anime)` check never sees it:
+ *
+ *   Failed to fetch from Subgraph 'anime-api'.
+ *     extensions.errors[0].message === "record not found"
+ */
+export function isNotFoundError(error: any): boolean {
+  const matches = (msg: unknown) => typeof msg === 'string' && /record not found/i.test(msg);
+
+  for (const err of error?.response?.errors ?? []) {
+    if (matches(err?.message)) return true;
+    for (const inner of err?.extensions?.errors ?? []) {
+      if (matches(inner?.message)) return true;
+    }
+  }
+  return false;
+}
+
 export interface SSRFetcher {
   fetchWithFallback: (query: any, variables: any, description: string) => Promise<any>;
   wasTokenExpired: () => boolean;

--- a/src/lib/structured-data.test.ts
+++ b/src/lib/structured-data.test.ts
@@ -1,0 +1,133 @@
+import {
+  animeSchema,
+  breadcrumbSchema,
+  isoDuration,
+  serializeJsonLd
+} from './structured-data';
+
+const CANON = 'https://weeb.vip/show/bd4134c1';
+const IMG = 'https://weeb.vip/og/bd4134c1';
+
+const FULL = {
+  titleEn: 'I Became a Legend After My 10 Year-Long Last Stand.',
+  titleJp: 'ここは俺に任せて先に行けと言ってから10年がたったら伝説になっていた。',
+  titleRomaji: null,
+  description: 'The sorcerer Luck believes this to be the end.',
+  episodeCount: 12,
+  startDate: '2026-07-06T04:00:00Z',
+  endDate: null,
+  duration: '23 min. per ep.',
+  tags: ['Action', 'Fantasy', 'Adventure'],
+  studios: ['Gekkou'],
+  malId: 62617
+};
+
+describe('isoDuration', () => {
+  it('converts the API format', () => {
+    expect(isoDuration('23 min. per ep.')).toBe('PT23M');
+    expect(isoDuration('1 hr. 45 min.')).toBe('PT1H45M');
+  });
+
+  it('drops anything unparseable rather than guessing', () => {
+    expect(isoDuration('unknown')).toBeNull();
+    expect(isoDuration('')).toBeNull();
+    expect(isoDuration(null)).toBeNull();
+  });
+});
+
+describe('animeSchema', () => {
+  it('builds a TVSeries from what the page already has', () => {
+    const s = animeSchema(FULL, CANON, IMG)!;
+
+    expect(s['@context']).toBe('https://schema.org');
+    expect(s['@type']).toBe('TVSeries');
+    expect(s.name).toBe(FULL.titleEn);
+    expect(s.alternateName).toBe(FULL.titleJp);
+    expect(s.numberOfEpisodes).toBe(12);
+    expect(s.genre).toEqual(['Action', 'Fantasy', 'Adventure']);
+    expect(s.productionCompany).toEqual([{ '@type': 'Organization', name: 'Gekkou' }]);
+    expect(s.timeRequired).toBe('PT23M');
+    expect(s.url).toBe(CANON);
+    expect(s.image).toBe(IMG);
+  });
+
+  it('emits a date, not a timestamp', () => {
+    // Same reasoning as sitemap lastmod: no zone is given, so claim only the date.
+    expect(animeSchema(FULL, CANON, IMG)!.startDate).toBe('2026-07-06');
+  });
+
+  it('links to MyAnimeList, because titles are not unique', () => {
+    // 2,301 anime in the catalogue share a title with another; malId disambiguates.
+    expect(animeSchema(FULL, CANON, IMG)!.sameAs).toBe('https://myanimelist.net/anime/62617');
+  });
+
+  it('treats a single-episode entry as a Movie with no episode count', () => {
+    const s = animeSchema({ ...FULL, episodeCount: 1 }, CANON, IMG)!;
+
+    expect(s['@type']).toBe('Movie');
+    expect(s).not.toHaveProperty('numberOfEpisodes');
+  });
+
+  it('never emits aggregateRating or contentRating', () => {
+    // `rating` is a MAL score ("6.7"), not a content advisory, and Google rejects
+    // aggregateRating with no ratingCount — which the API does not provide.
+    const s = animeSchema({ ...FULL, ...({ rating: '6.7' } as any) }, CANON, IMG)!;
+
+    expect(s).not.toHaveProperty('aggregateRating');
+    expect(s).not.toHaveProperty('contentRating');
+  });
+
+  it('omits empty fields instead of emitting nulls', () => {
+    const s = animeSchema(
+      { titleEn: 'Bare', description: null, tags: [], studios: [], malId: null },
+      CANON,
+      IMG
+    )!;
+
+    expect(s).not.toHaveProperty('description');
+    expect(s).not.toHaveProperty('genre');
+    expect(s).not.toHaveProperty('productionCompany');
+    expect(s).not.toHaveProperty('sameAs');
+    expect(s.name).toBe('Bare');
+  });
+
+  it('falls back to the Japanese title, and does not repeat it as an alternate', () => {
+    const s = animeSchema({ titleEn: null, titleJp: '進撃の巨人' }, CANON, IMG)!;
+
+    expect(s.name).toBe('進撃の巨人');
+    expect(s).not.toHaveProperty('alternateName');
+  });
+
+  it('returns null when there is no title at all', () => {
+    expect(animeSchema({ titleEn: null, titleJp: null }, CANON, IMG)).toBeNull();
+  });
+});
+
+describe('breadcrumbSchema', () => {
+  it('numbers positions from 1', () => {
+    const s = breadcrumbSchema([
+      { name: 'Home', url: 'https://weeb.vip/' },
+      { name: 'Show', url: CANON }
+    ])!;
+
+    expect(s['@type']).toBe('BreadcrumbList');
+    expect(s.itemListElement).toEqual([
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://weeb.vip/' },
+      { '@type': 'ListItem', position: 2, name: 'Show', item: CANON }
+    ]);
+  });
+
+  it('returns null for an empty trail', () => {
+    expect(breadcrumbSchema([])).toBeNull();
+  });
+});
+
+describe('serializeJsonLd', () => {
+  it('escapes < so a description cannot break out of the script tag', () => {
+    const out = serializeJsonLd({ description: '</script><script>alert(1)</script>' });
+
+    expect(out).not.toContain('</script>');
+    expect(out).toContain('\\u003c');
+    expect(JSON.parse(out).description).toBe('</script><script>alert(1)</script>');
+  });
+});

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,128 @@
+// schema.org JSON-LD builders.
+//
+// Everything here is derived from data the page already loads — no new queries, no
+// new storage. The point is to restate what is on the page in a form Google can use
+// for rich results (episode counts, air dates, breadcrumb trails in the SERP).
+
+export interface AnimeLike {
+  id?: string | null;
+  titleEn?: string | null;
+  titleJp?: string | null;
+  titleRomaji?: string | null;
+  description?: string | null;
+  episodeCount?: number | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  duration?: string | null;
+  tags?: string[] | null;
+  studios?: string[] | null;
+  malId?: number | null;
+}
+
+/** A date the way schema.org wants it: YYYY-MM-DD, no time, no zone guessing. */
+function schemaDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(String(raw).trim());
+  return m ? m[1] : null;
+}
+
+/**
+ * "23 min. per ep." -> "PT23M". Anything unparseable is dropped rather than guessed:
+ * an invalid duration is worse than an absent one.
+ */
+export function isoDuration(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const h = /(\d+)\s*hr/i.exec(raw);
+  const m = /(\d+)\s*min/i.exec(raw);
+  if (!h && !m) return null;
+  return `PT${h ? `${h[1]}H` : ''}${m ? `${m[1]}M` : ''}`;
+}
+
+function clean<T extends Record<string, unknown>>(obj: T): T {
+  for (const k of Object.keys(obj)) {
+    const v = obj[k];
+    if (v === null || v === undefined || v === '' || (Array.isArray(v) && v.length === 0)) {
+      delete obj[k];
+    }
+  }
+  return obj;
+}
+
+/**
+ * TVSeries (or Movie for a single-episode entry) describing one anime.
+ *
+ * Two fields are deliberately NOT mapped:
+ *
+ * - `rating` holds a MyAnimeList score like "6.7". It is tempting to emit it as
+ *   contentRating, but contentRating means "PG-13" — a content advisory, not a score.
+ * - As aggregateRating it would need ratingCount or reviewCount, which the API does
+ *   not expose. Google rejects aggregateRating without a count, so emitting one would
+ *   invalidate the whole block rather than add a star rating.
+ */
+export function animeSchema(
+  anime: AnimeLike,
+  canonicalUrl: string,
+  imageUrl: string
+): Record<string, unknown> | null {
+  const name = anime.titleEn || anime.titleJp;
+  if (!name) return null;
+
+  // No explicit type on the record, so infer: a single-episode entry is a film.
+  const isMovie = anime.episodeCount === 1;
+
+  const alternateNames = [anime.titleJp, anime.titleRomaji].filter(
+    (t): t is string => Boolean(t) && t !== name
+  );
+
+  return clean({
+    '@context': 'https://schema.org',
+    '@type': isMovie ? 'Movie' : 'TVSeries',
+    name,
+    alternateName: alternateNames.length === 1 ? alternateNames[0] : alternateNames,
+    description: anime.description || null,
+    url: canonicalUrl,
+    image: imageUrl,
+    genre: anime.tags ?? [],
+    inLanguage: 'ja',
+    // Episode counts are meaningless on a film.
+    numberOfEpisodes: isMovie ? null : (anime.episodeCount ?? null),
+    startDate: schemaDate(anime.startDate),
+    endDate: schemaDate(anime.endDate),
+    timeRequired: isoDuration(anime.duration),
+    productionCompany: (anime.studios ?? []).map((s) => ({
+      '@type': 'Organization',
+      name: s
+    })),
+    // The disambiguator. 2,301 anime in the catalogue share a title with another, so
+    // name alone cannot identify an entity — the MyAnimeList URL can.
+    sameAs: anime.malId ? `https://myanimelist.net/anime/${anime.malId}` : null
+  });
+}
+
+export interface Crumb {
+  name: string;
+  url: string;
+}
+
+/** BreadcrumbList. Derived purely from the path — needs no data of its own. */
+export function breadcrumbSchema(crumbs: Crumb[]): Record<string, unknown> | null {
+  if (!crumbs.length) return null;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: crumbs.map((c, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: c.name,
+      item: c.url
+    }))
+  };
+}
+
+/**
+ * Serialise for embedding in a <script> tag. `<` is escaped so a description
+ * containing "</script>" cannot break out of the block.
+ */
+export function serializeJsonLd(schema: unknown): string {
+  return JSON.stringify(schema).replace(/</g, '\\u003c');
+}

--- a/src/routes/show/[id]/+page.server.ts
+++ b/src/routes/show/[id]/+page.server.ts
@@ -1,9 +1,9 @@
-import { redirect } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 // use the same typed documents the client uses — a raw copy here drifts
 // (it already had: missing userAnime.episodes)
 import { getAnimeDetailsByID, queryCharactersAndStaffByAnimeID } from '../../../services/api/graphql/queries';
-import { createSSRGraphQLClient, cookieHeaderFrom } from '$lib/server/ssr-graphql';
+import { createSSRGraphQLClient, cookieHeaderFrom, isNotFoundError } from '$lib/server/ssr-graphql';
 
 export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   const { id } = params;
@@ -19,7 +19,9 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   let animeImage = '/assets/og-image.jpg';
   let animeData: any = null;
   let charactersData: any = null;
-  let error: string | null = null;
+  // Not named `error`: that would shadow SvelteKit's error() helper imported above.
+  let loadError: string | null = null;
+  let error404 = false;
 
   try {
     // Forward the user's cookies — the gateway authenticates via cookie,
@@ -49,9 +51,31 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
       // disallows /*?*, which would hide it from the crawlers that need it.
       animeImage = `/og/${encodeURIComponent(id)}`;
     }
+    // The query succeeded and there is no such anime: a genuine 404. This used to
+    // return 200 with the placeholder title above, a soft 404 — which means every
+    // stale or mistyped id in the 32,000-URL sitemap could be indexed as an empty
+    // page competing with real ones.
+    //
+    // Guarded on the request having actually succeeded. A gateway blip must not be
+    // reported as "gone", or Google would start dropping real pages; that case still
+    // falls through to the catch and renders with ssrError, where the client can
+    // recover on hydration.
+    if (!animeData?.anime) {
+      error404 = true;
+    }
   } catch (err: any) {
-    console.error('[SSR] Failed to fetch anime data:', err);
-    error = err?.message || 'Failed to fetch anime data';
+    // A missing anime arrives here as a thrown DOWNSTREAM_SERVICE_ERROR, not as a
+    // null field, so it has to be separated from a genuine gateway failure.
+    if (isNotFoundError(err)) {
+      error404 = true;
+    } else {
+      console.error('[SSR] Failed to fetch anime data:', err);
+      loadError = err?.message || 'Failed to fetch anime data';
+    }
+  }
+
+  if (error404) {
+    error(404, 'Anime not found');
   }
 
   return {
@@ -59,8 +83,26 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
     animeTitle,
     animeDescription,
     animeImage,
+    // The subset the JSON-LD builder needs. Passed explicitly rather than reaching
+    // into ssrAnimeData from the component, so the schema does not silently break
+    // if the query's shape changes.
+    animeSchemaSource: animeData?.anime
+      ? {
+          titleEn: animeData.anime.titleEn,
+          titleJp: animeData.anime.titleJp,
+          titleRomaji: animeData.anime.titleRomaji,
+          description: animeData.anime.description,
+          episodeCount: animeData.anime.episodeCount,
+          startDate: animeData.anime.startDate,
+          endDate: animeData.anime.endDate,
+          duration: animeData.anime.duration,
+          tags: animeData.anime.tags,
+          studios: animeData.anime.studios,
+          malId: animeData.anime.malId
+        }
+      : null,
     ssrAnimeData: animeData,
     ssrCharactersData: charactersData,
-    ssrError: error
+    ssrError: loadError
   };
 };

--- a/src/routes/show/[id]/+page.svelte
+++ b/src/routes/show/[id]/+page.svelte
@@ -1,8 +1,26 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import Seo from '$lib/Seo.svelte';
+  import StructuredData from '$lib/StructuredData.svelte';
+  import { animeSchema, breadcrumbSchema } from '$lib/structured-data';
   import ShowContentWithProvider from '../../../svelte/components/ShowContentWithProvider.svelte';
 
   export let data;
+
+  const SITE_URL = 'https://weeb.vip';
+
+  // Canonical host, not the request origin: these URLs identify the entity, and must
+  // match the canonical tag rather than whichever deployment served the page.
+  $: canonical = `${SITE_URL}/show/${data.animeId}`;
+  $: schemas = [
+    data.animeSchemaSource
+      ? animeSchema(data.animeSchemaSource, canonical, new URL(data.animeImage, $page.url.origin).toString())
+      : null,
+    breadcrumbSchema([
+      { name: 'Home', url: `${SITE_URL}/` },
+      { name: data.animeTitle, url: canonical }
+    ])
+  ];
 </script>
 
 <Seo
@@ -10,6 +28,8 @@
   description={data.animeDescription}
   image={data.animeImage}
 />
+
+<StructuredData {schemas} />
 
 {#key data.animeId}
   <ShowContentWithProvider

--- a/src/routes/show/[id]/news/+page.server.ts
+++ b/src/routes/show/[id]/news/+page.server.ts
@@ -1,7 +1,7 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getAnimeNewsByID } from '../../../../services/api/graphql/queries';
-import { createSSRGraphQLClient, cookieHeaderFrom } from '$lib/server/ssr-graphql';
+import { createSSRGraphQLClient, cookieHeaderFrom, isNotFoundError } from '$lib/server/ssr-graphql';
 
 export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   const { id } = params;
@@ -48,6 +48,10 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
     // A 404 thrown above arrives here as a SvelteKit HttpError — rethrow it
     // rather than reporting a missing anime as a load failure.
     if (e?.status) throw e;
+    // The `!anime` check above never actually fires: the router reports a missing
+    // record by throwing a DOWNSTREAM_SERVICE_ERROR, not by returning null. Without
+    // this the page answered 200 for any bogus id — a soft 404.
+    if (isNotFoundError(e)) error(404, 'Anime not found');
     return {
       animeId: id,
       animeTitle: 'Anime',

--- a/src/routes/show/[id]/news/+page.svelte
+++ b/src/routes/show/[id]/news/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Seo from '$lib/Seo.svelte';
+  import StructuredData from '$lib/StructuredData.svelte';
+  import { breadcrumbSchema } from '$lib/structured-data';
   import SafeImage from '../../../../svelte/components/SafeImage.svelte';
   import AnimeNews from '../../../../svelte/components/AnimeNews.svelte';
   import { GetImageFromAnime, getYearUTC } from '../../../../services/utils';
@@ -99,13 +101,24 @@
   const goPage = (n: number) => navigate({ page: n });
 
   const label = (c: string) => c.charAt(0).toUpperCase() + c.slice(1);
+
+  const SITE_URL = 'https://weeb.vip';
+  // Trailing "." on a title would otherwise produce "…Last Stand.." in the description.
+  $: descTitle = data.animeTitle.replace(/\.+$/, '');
+  $: breadcrumbs = breadcrumbSchema([
+    { name: 'Home', url: `${SITE_URL}/` },
+    { name: data.animeTitle, url: `${SITE_URL}/show/${data.animeId}` },
+    { name: 'News', url: `${SITE_URL}/show/${data.animeId}/news` }
+  ]);
 </script>
 
 <Seo
   title={`${data.animeTitle} — News`}
-  description={`All ${news.length} news ${news.length === 1 ? 'story' : 'stories'} for ${data.animeTitle}.`}
+  description={`All ${news.length} news ${news.length === 1 ? 'story' : 'stories'} for ${descTitle}.`}
   image={data.animeImage}
 />
+
+<StructuredData schemas={[breadcrumbs]} />
 
 <div class="news-page">
   <a class="back" href={`/show/${data.animeId}`}>


### PR DESCRIPTION
Items 1 and 2 from the site audit.

## 1. Soft 404s

`/show/<any-uuid>` answered **200** with the placeholder title "Anime Details", no `<h1>`, and a canonical pointing at itself:

```
before:  /show/00000000-0000-0000-0000-000000000000  ->  HTTP 200
after:                                                   HTTP 404
```

With 32,000 URLs in the sitemap, every stale or mistyped id could be indexed as an empty page competing with real ones.

**Why the existing guard never fired.** The news route already had `if (!anime) error(404, ...)`, and it never ran — because the federation router reports a missing record by *throwing*, not by returning a null field:

```
Failed to fetch from Subgraph 'anime-api'.
  extensions.errors[0].message === "record not found"
  extensions.errors[0].extensions.code === "DOWNSTREAM_SERVICE_ERROR"
```

So the thrown error landed in the catch block and the page rendered with defaults. `isNotFoundError()` unpicks that shape.

It **deliberately distinguishes not-found from a gateway failure**. Answering 404 during a transient outage would tell Google that real pages are gone, so only `record not found` produces a 404; anything else still falls through to the existing error path where the client can recover on hydration. There's a test pinning that negative case.

## 2. Structured data

Every page emitted the same generic `WebSite` block and nothing else. Now:

| Page | Emits |
|---|---|
| `/show/<id>` | `WebSite` + **`TVSeries`** (or `Movie`) + **`BreadcrumbList`** |
| `/show/<id>/news` | `WebSite` + **`BreadcrumbList`** (3 levels) |

`TVSeries` carries name, alternateName, description, genre, productionCompany, numberOfEpisodes, startDate/endDate, timeRequired and sameAs — all from data the pages already load. **No new queries, no new tables, no Algolia involvement.**

**Two fields deliberately not mapped:**

- `rating` holds a MyAnimeList score (`"6.7"`). That is not what `contentRating` means — it's a content advisory like "PG-13".
- As `aggregateRating` it would need `ratingCount` or `reviewCount`, which the API doesn't expose. Google rejects `aggregateRating` without a count, so emitting one would invalidate the entire block rather than add a star rating.

**`sameAs` points at MyAnimeList** because **2,301 anime (7.2%) share a title** with another in the catalogue — name alone cannot identify an entity, and `https://myanimelist.net/anime/{malId}` is exactly the signal Google uses to disambiguate.

Single-episode entries are typed `Movie` and omit `numberOfEpisodes`, since there's no explicit type on the record.

Dates are emitted as `YYYY-MM-DD` rather than the raw timestamp — same reasoning as the sitemap `lastmod`: no zone is given, so don't claim precision we don't have.

Also fixes the news description rendering as `"...Last Stand.."` when a title ends in a period.

## Verification

**136 tests pass** (18 new). Against a production build hitting the real API:

```
real show      -> HTTP 200      bogus show  -> HTTP 404
real news      -> HTTP 200      bogus news  -> HTTP 404

/show/<id>       WebSite, TVSeries, BreadcrumbList     all parse as valid JSON
/show/<id>/news  WebSite, BreadcrumbList               all parse as valid JSON
```

Worth pasting a live show URL into the [Rich Results Test](https://search.google.com/test/rich-results) once deployed.

## Found while auditing, not fixed here

**1,188 CDN image slugs are shared by 2,385 anime.** `GetImageFromAnime` derives the CDN key from the title, so all four anime named "Promise" resolve to the same poster URL and three display the wrong artwork. The fix is keying posters on `id` the way `banners/<id>` already does. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
