### PR TITLE
chore: push OG_PROBE_SECRET to Pages before deploying

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -84,6 +84,28 @@ jobs:
           VITE_APP_VERSION: ${{ inputs.tag }}
           NODE_ENV: production
 
+      # Runtime secrets, pushed before the deploy so the new version starts with them.
+      #
+      # These cannot be baked in at build time: SvelteKit reads them through
+      # $env/dynamic/private, which on Pages resolves against the deployment's own
+      # environment, not the build environment. Setting them in the build step above
+      # would leave them undefined at request time.
+      #
+      # Production only. Staging runs in k8s and takes its config from weeb-argocd.
+      # OG_PROBE_SECRET lets /og/<id> check whether a CDN image exists. Cloudflare
+      # bot-challenges server-side requests to cdn.weeb.vip/weeb/*, and the WAF rule
+      # that lets this origin through matches on an x-og-probe header carrying this
+      # value. Without it every anime falls back to the branded default card.
+      - name: Sync runtime secrets to Pages
+        if: inputs.environment == 'production'
+        run: |
+          printf '%s' "$OG_PROBE_SECRET" \
+            | yarn wrangler pages secret put OG_PROBE_SECRET --project-name=weeb-production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          OG_PROBE_SECRET: ${{ secrets.OG_PROBE_SECRET }}
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
Wires up the secret that makes `/og/<id>` able to check the CDN, so share cards show real artwork instead of the placeholder.

## Why a separate step rather than build env

The value **cannot** be baked in at build time. SvelteKit reads it through `$env/dynamic/private`, which on Pages resolves against the *deployment's* environment, not the build environment — setting it next to `APP_CONFIG` would leave it `undefined` at request time.

It has to be a Pages project secret, and [Cloudflare requires it to be set before the deployment that uses it](https://developers.cloudflare.com/pages/functions/bindings/):

> When setting secrets with Wrangler or in the Cloudflare dashboard, it needs to be done before a deployment that uses those secrets.

Hence a step ordered ahead of `pages deploy`.

Production only — staging runs in k8s and takes its config from weeb-argocd.

## Already done outside this PR

- `OG_PROBE_SECRET` added to repo secrets
- The secret is already set on the `weeb-production` Pages project, so this PR is really about reproducibility: GitHub secrets is the source of truth, and a recreated project picks it up on the next deploy instead of silently serving placeholder cards.
- WAF rule `798e04ba168441e49f51aae8a00e2cee` created on zone `weeb.vip`, skipping managed rules for `cdn.weeb.vip/weeb/*` when the header matches.

## Verified

The rule works — same request, with and without the header:

```
with header:   206      without: 403      wrong secret: 403
```

And end to end against a local production build with the secret set:

```
bd4134c1 → cdn.weeb.vip/cdn-cgi/image/…/weeb/…   200 image/jpeg
d0cfc01b → cdn.weeb.vip/cdn-cgi/image/…/weeb/…   200 image/jpeg
12ae81a9 → /assets/og-image.jpg                   (no CDN image exists)
```

`wrangler pages secret put <key> --project-name` confirmed against the pinned wrangler in this repo rather than assumed.

## Order of operations

This does nothing on its own — **#84 must merge first**, since that's what adds the header to the probe. Then deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
