### PR TITLE
fix: give every page one real h1, and stop throttling Bing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,8 +4,10 @@ Allow: /
 # Sitemap
 Sitemap: https://weeb.vip/sitemap.xml
 
-# Crawl-delay for respectful crawling
-Crawl-delay: 1
+# No Crawl-delay. Google ignores it, but Bing and Yandex honour it — at one request
+# per second the ~32,000 show pages take over nine hours of continuous crawling to
+# get through, which throttles indexing far more than it protects the origin. The
+# site is behind Cloudflare; rate limiting belongs there, not here.
 
 # Disallow private/auth areas
 Disallow: /auth/

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,9 @@
   export let data;
 </script>
 
+<!-- No title, so Seo falls back to "WeebVIP - Track Your Anime Watchlist". This is the
+     most-linked page on the site and "Home | WeebVIP" says nothing about what it is. -->
 <Seo
-  title="Home"
   description="Discover and track your favorite anime. Get notifications for new episodes, explore seasonal anime, and manage your watchlist."
 />
 

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,8 +3,9 @@
   import AboutPage from '../../svelte/components/AboutPage.svelte';
 </script>
 
+<!-- Seo appends "| WeebVIP", so "About WeebVIP" rendered as "About WeebVIP | WeebVIP". -->
 <Seo
-  title="About WeebVIP"
+  title="About"
   description="Learn about WeebVIP - the ultimate platform for tracking your anime watchlist, getting episode notifications, and discovering new seasonal anime."
 />
 

--- a/src/svelte/components/AboutPage.svelte
+++ b/src/svelte/components/AboutPage.svelte
@@ -1,198 +1,184 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { fade, fly } from 'svelte/transition';
 
-  let mounted = false;
-
-  onMount(() => {
-    mounted = true;
-  });
+  // The whole template used to sit behind `{#if mounted}`, flipped in onMount, so the
+  // page server-rendered nothing at all: crawlers saw an empty document and the h1
+  // never existed in the HTML. The intro transitions below still play on client-side
+  // navigation — they just no longer decide whether the content exists.
 </script>
 
-{#if mounted}
-  <div class="min-h-screen bg-weeb-surface transition-colors duration-300">
+<div class="min-h-screen bg-weeb-surface transition-colors duration-300">
 
-    <!-- Header -->
-    <div class="bg-weeb-bg-elevated border-b border-weeb-border transition-colors duration-300">
-      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div class="text-center" in:fade="{{ duration: 600, delay: 100 }}">
-          <h1 class="text-4xl font-bold text-weeb-fg text-weeb-fg mb-4">About WeebVIP</h1>
-          <p class="text-lg text-weeb-fg-secondary">
-            A modern anime tracking platform built for anime enthusiasts
-          </p>
-        </div>
+  <!-- Header -->
+  <div class="bg-weeb-bg-elevated border-b border-weeb-border transition-colors duration-300">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div class="text-center" in:fade="{{ duration: 600, delay: 100 }}">
+        <h1 class="text-4xl font-bold text-weeb-fg text-weeb-fg mb-4">About WeebVIP</h1>
+        <p class="text-lg text-weeb-fg-secondary">
+          A modern anime tracking platform built for anime enthusiasts
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main Content -->
+  <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+
+    <!-- What is WeebVIP -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 200 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">What is WeebVIP?</h2>
+      <div class="prose prose-lg max-w-none text-weeb-fg-secondary">
+        <p class="mb-4">
+          WeebVIP is an anime tracking platform that helps you manage your anime watching experience.
+          It provides tools to track what you're currently watching, plan your next shows, and get
+          notifications when new episodes are released.
+        </p>
+        <p>
+          The platform was designed to be simple, fast, and focused on the core functionality that
+          anime fans need most - keeping track of their watchlist and staying up to date with new episodes.
+        </p>
       </div>
     </div>
 
-    <!-- Main Content -->
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <!-- Core Features -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 300 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Core Features</h2>
+      <div class="space-y-6">
 
-      <!-- What is WeebVIP -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 200 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">What is WeebVIP?</h2>
-        <div class="prose prose-lg max-w-none text-weeb-fg-secondary">
-          <p class="mb-4">
-            WeebVIP is an anime tracking platform that helps you manage your anime watching experience.
-            It provides tools to track what you're currently watching, plan your next shows, and get
-            notifications when new episodes are released.
-          </p>
-          <p>
-            The platform was designed to be simple, fast, and focused on the core functionality that
-            anime fans need most - keeping track of their watchlist and staying up to date with new episodes.
-          </p>
-        </div>
-      </div>
-
-      <!-- Core Features -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 300 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Core Features</h2>
-        <div class="space-y-6">
-
-          <div class="border-l-4 border-weeb-accent pl-4">
-            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Anime Tracking</h3>
-            <p class="text-weeb-fg-secondary">
-              Keep track of anime across different statuses: Currently Watching, Plan to Watch, Completed,
-              On Hold, and Dropped. Update your progress and manage your personal anime database.
-            </p>
-          </div>
-
-          <div class="border-l-4 border-green-500 pl-4">
-            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Episode Notifications</h3>
-            <p class="text-weeb-fg-secondary">
-              Get notified when new episodes of anime in your watchlist are released. The system tracks
-              broadcast schedules and sends timely notifications so you never miss an episode.
-            </p>
-          </div>
-
-          <div class="border-l-4 border-purple-500 pl-4">
-            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Seasonal Discovery</h3>
-            <p class="text-weeb-fg-secondary">
-              Browse currently airing anime and explore seasonal catalogs. Find new shows to add to
-              your watchlist and stay current with what's popular each season.
-            </p>
-          </div>
-
-          <div class="border-l-4 border-orange-500 pl-4">
-            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Search & Information</h3>
-            <p class="text-weeb-fg-secondary">
-              Search through a comprehensive anime database with detailed information including
-              descriptions, episode counts, air dates, studios, and more.
-            </p>
-          </div>
-
-        </div>
-      </div>
-
-      <!-- Technical Information -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 400 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Technical Details</h2>
-        <div class="bg-weeb-bg-elevated rounded-lg p-6 border border-weeb-border">
-
-          <div class="grid md:grid-cols-2 gap-6">
-            <div>
-              <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Frontend</h3>
-              <ul class="space-y-1 text-weeb-fg-secondary">
-                <li>• Built with Astro and Svelte</li>
-                <li>• Styled with TailwindCSS</li>
-                <li>• Responsive design for all devices</li>
-                <li>• Dark and light theme support</li>
-                <li>• Progressive Web App features</li>
-              </ul>
-            </div>
-
-            <div>
-              <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Data & Search</h3>
-              <ul class="space-y-1 text-weeb-fg-secondary">
-                <li>• GraphQL API for data queries</li>
-                <li>• Algolia-powered search</li>
-                <li>• Real-time episode tracking</li>
-                <li>• Broadcast schedule integration</li>
-                <li>• Comprehensive anime metadata</li>
-              </ul>
-            </div>
-          </div>
-
-          <div class="mt-6 pt-6 border-t border-weeb-border">
-            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Performance & Accessibility</h3>
-            <p class="text-weeb-fg-secondary">
-              The site is optimized for performance with server-side rendering, efficient caching,
-              and minimal JavaScript for core functionality. It follows web accessibility standards
-              and works without JavaScript for basic browsing.
-            </p>
-          </div>
-
-        </div>
-      </div>
-
-      <!-- Data Sources -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 500 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Data Sources</h2>
-        <div class="prose max-w-none text-weeb-fg-secondary">
-          <p class="mb-4">
-            WeebVIP aggregates anime information from multiple sources to provide comprehensive
-            and up-to-date data. This includes basic anime information, episode schedules,
-            broadcast times, and metadata.
-          </p>
-          <p>
-            The platform focuses on accuracy and timeliness, especially for episode release
-            schedules and broadcast information that powers the notification system.
-          </p>
-        </div>
-      </div>
-
-      <!-- Development -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 600 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Development</h2>
-        <div class="prose max-w-none text-weeb-fg-secondary">
-          <p class="mb-4">
-            WeebVIP is actively developed with a focus on user experience and reliability.
-            The platform is continuously updated with bug fixes, performance improvements,
-            and new features based on user feedback.
-          </p>
-          <p>
-            Development priorities include maintaining accurate episode schedules, improving
-            search functionality, and ensuring the platform remains fast and accessible
-            across all devices.
-          </p>
-        </div>
-      </div>
-
-      <!-- Contact/Feedback -->
-      <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 700 }}">
-        <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Feedback & Support</h2>
-        <div class="bg-weeb-surface border border-weeb-border rounded-lg p-6">
-          <p class="text-weeb-fg-secondary mb-4">
-            WeebVIP is an ongoing project that benefits from user feedback. If you encounter
-            any issues, have suggestions for improvements, or notice incorrect anime information,
-            your input helps make the platform better for everyone.
-          </p>
+        <div class="border-l-4 border-weeb-accent pl-4">
+          <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Anime Tracking</h3>
           <p class="text-weeb-fg-secondary">
-            The platform aims to be a reliable tool for anime fans without unnecessary complexity
-            or bloated features - focusing on doing the core functionality really well.
+            Keep track of anime across different statuses: Currently Watching, Plan to Watch, Completed,
+            On Hold, and Dropped. Update your progress and manage your personal anime database.
           </p>
         </div>
-      </div>
 
-    </div>
-
-    <!-- Simple Footer -->
-    <div class="bg-weeb-bg-elevated border-t border-weeb-border mt-16">
-      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div class="text-center text-sm text-weeb-fg-muted">
-          <p>WeebVIP - Built for anime enthusiasts</p>
+        <div class="border-l-4 border-green-500 pl-4">
+          <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Episode Notifications</h3>
+          <p class="text-weeb-fg-secondary">
+            Get notified when new episodes of anime in your watchlist are released. The system tracks
+            broadcast schedules and sends timely notifications so you never miss an episode.
+          </p>
         </div>
+
+        <div class="border-l-4 border-purple-500 pl-4">
+          <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Seasonal Discovery</h3>
+          <p class="text-weeb-fg-secondary">
+            Browse currently airing anime and explore seasonal catalogs. Find new shows to add to
+            your watchlist and stay current with what's popular each season.
+          </p>
+        </div>
+
+        <div class="border-l-4 border-orange-500 pl-4">
+          <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-2">Search & Information</h3>
+          <p class="text-weeb-fg-secondary">
+            Search through a comprehensive anime database with detailed information including
+            descriptions, episode counts, air dates, studios, and more.
+          </p>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Technical Information -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 400 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Technical Details</h2>
+      <div class="bg-weeb-bg-elevated rounded-lg p-6 border border-weeb-border">
+
+        <div class="grid md:grid-cols-2 gap-6">
+          <div>
+            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Frontend</h3>
+            <ul class="space-y-1 text-weeb-fg-secondary">
+              <li>• Built with Astro and Svelte</li>
+              <li>• Styled with TailwindCSS</li>
+              <li>• Responsive design for all devices</li>
+              <li>• Dark and light theme support</li>
+              <li>• Progressive Web App features</li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Data & Search</h3>
+            <ul class="space-y-1 text-weeb-fg-secondary">
+              <li>• GraphQL API for data queries</li>
+              <li>• Algolia-powered search</li>
+              <li>• Real-time episode tracking</li>
+              <li>• Broadcast schedule integration</li>
+              <li>• Comprehensive anime metadata</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="mt-6 pt-6 border-t border-weeb-border">
+          <h3 class="text-lg font-medium text-weeb-fg text-weeb-fg mb-3">Performance & Accessibility</h3>
+          <p class="text-weeb-fg-secondary">
+            The site is optimized for performance with server-side rendering, efficient caching,
+            and minimal JavaScript for core functionality. It follows web accessibility standards
+            and works without JavaScript for basic browsing.
+          </p>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- Data Sources -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 500 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Data Sources</h2>
+      <div class="prose max-w-none text-weeb-fg-secondary">
+        <p class="mb-4">
+          WeebVIP aggregates anime information from multiple sources to provide comprehensive
+          and up-to-date data. This includes basic anime information, episode schedules,
+          broadcast times, and metadata.
+        </p>
+        <p>
+          The platform focuses on accuracy and timeliness, especially for episode release
+          schedules and broadcast information that powers the notification system.
+        </p>
+      </div>
+    </div>
+
+    <!-- Development -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 600 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Development</h2>
+      <div class="prose max-w-none text-weeb-fg-secondary">
+        <p class="mb-4">
+          WeebVIP is actively developed with a focus on user experience and reliability.
+          The platform is continuously updated with bug fixes, performance improvements,
+          and new features based on user feedback.
+        </p>
+        <p>
+          Development priorities include maintaining accurate episode schedules, improving
+          search functionality, and ensuring the platform remains fast and accessible
+          across all devices.
+        </p>
+      </div>
+    </div>
+
+    <!-- Contact/Feedback -->
+    <div class="mb-12" in:fly="{{ y: 30, duration: 500, delay: 700 }}">
+      <h2 class="text-2xl font-semibold text-weeb-fg text-weeb-fg mb-6">Feedback & Support</h2>
+      <div class="bg-weeb-surface border border-weeb-border rounded-lg p-6">
+        <p class="text-weeb-fg-secondary mb-4">
+          WeebVIP is an ongoing project that benefits from user feedback. If you encounter
+          any issues, have suggestions for improvements, or notice incorrect anime information,
+          your input helps make the platform better for everyone.
+        </p>
+        <p class="text-weeb-fg-secondary">
+          The platform aims to be a reliable tool for anime fans without unnecessary complexity
+          or bloated features - focusing on doing the core functionality really well.
+        </p>
       </div>
     </div>
 
   </div>
-{:else}
-  <!-- Loading skeleton -->
-  <div class="min-h-screen bg-weeb-surface">
-    <div class="bg-weeb-surface h-32 animate-pulse"></div>
-    <div class="max-w-4xl mx-auto px-4 py-12 space-y-8">
-      {#each Array(6) as _}
-        <div class="bg-weeb-surface h-24 rounded animate-pulse"></div>
-      {/each}
+
+  <!-- Simple Footer -->
+  <div class="bg-weeb-bg-elevated border-t border-weeb-border mt-16">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div class="text-center text-sm text-weeb-fg-muted">
+        <p>WeebVIP - Built for anime enthusiasts</p>
+      </div>
     </div>
   </div>
-{/if}
+
+</div>

--- a/src/svelte/components/HeroBanner.svelte
+++ b/src/svelte/components/HeroBanner.svelte
@@ -151,7 +151,10 @@
       </div>
     {/if}
 
-    <h1>{title}</h1>
+    <!-- h2, not h1: this is one rotating featured item, so as an h1 the homepage's
+         primary heading changed with whatever the carousel happened to show. The
+         page-level h1 lives in HomepageSSR. -->
+    <h2>{title}</h2>
 
     {#if anime.description}
       <p class="hero-desc">
@@ -303,7 +306,7 @@
     background: oklch(0% 0 0 / 0.25);
     font-size: 10px;
   }
-  .hero h1 {
+  .hero h2 {
     font-size: clamp(28px, 4vw, 44px);
     font-weight: 700;
     letter-spacing: -0.02em;
@@ -388,7 +391,7 @@
   }
   @media (max-width: 768px) {
     .hero { min-height: 560px; }
-    .hero h1 { font-size: 24px; }
+    .hero h2 { font-size: 24px; }
   }
   @media (max-width: 480px) {
     .hero-content { padding: 0 16px 24px; }

--- a/src/svelte/components/HomepageSSR.svelte
+++ b/src/svelte/components/HomepageSSR.svelte
@@ -371,6 +371,12 @@
 </script>
 
 <div class="homepage">
+  <!-- The page's actual heading. Visually hidden because the design leads with the hero
+       carousel rather than a title, but the document still needs one h1 describing the
+       page: the only h1 used to be the carousel's current anime, so the homepage's
+       primary heading changed with whichever show happened to be featured. -->
+  <h1 class="sr-only">WeebVIP — track your anime watchlist</h1>
+
   <!-- Hero Banner Section -->
   {#if sortedCurrentlyAiring.length > 0}
     <div class="hero-wrapper">

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -394,9 +394,12 @@
               fallbackSrc="/assets/not found.jpg"
             />
             <div class="min-w-0 flex-1">
-              <h1 class="text-base font-semibold text-weeb-fg truncate">
+              <!-- Not an h1: this is the sticky compact header, which repeats the title
+                   as navigation chrome. The page's h1 is the hero title further down,
+                   and having both made every show page emit two identical h1s. -->
+              <p class="text-base font-semibold text-weeb-fg truncate">
                 {animeTitle}
-              </h1>
+              </p>
               <p class="text-xs text-weeb-fg-secondary truncate">
                 {getYearUTC(anime.startDate)} • {anime.endDate ? "Finished" : "Ongoing"}
                 {#if anime.studios && anime.studios.length > 0}


### PR DESCRIPTION
Items 4 and 5 from the audit. One of them turned out to be much worse than "missing heading".

## `/about` server-rendered nothing at all

The entire template sat behind `{#if mounted}`, flipped in `onMount`:

```svelte
let mounted = false;
onMount(() => { mounted = true; });

{#if mounted}
  … the whole page …
{:else}
  … loading skeleton …
{/if}
```

So crawlers received an empty document — not a missing `<h1>`, **no content whatsoever**. It renders on the server now:

```
before:  h1 x0    13,703 bytes    (shell only)
after:   h1 x1    18,083 bytes    3,111 chars of visible text, 5 headings
```

The intro transitions still play on client-side navigation; they just no longer gate whether the content exists. The `{:else}` skeleton goes with them, since nothing is loading any more.

## The homepage `<h1>` was whatever the carousel was showing

It changed on rotation — I caught it as "Young Ladies Don't Play Fighting Games" one visit and "The Villager of Level 999" another. The hero title becomes an `h2`, alongside the section headings it already sits with, and the page gets a real `h1`.

That `h1` is visually hidden: the design leads with the carousel rather than a title, so there's nowhere visible to put one, but the document still needs it. Same text a sighted user infers from the page — not cloaking.

## Show pages emitted two identical `<h1>`s

The sticky compact header repeats the title as navigation chrome. That becomes a `<p>`; the hero title stays the `h1`.

## Titles

| Page | Before | After |
|---|---|---|
| `/about` | `About WeebVIP \| WeebVIP` | `About \| WeebVIP` |
| `/` | `Home \| WeebVIP` | `WeebVIP - Track Your Anime Watchlist` |

`Seo` already appends the brand, so `/about` was doubling it. The homepage passed `"Home"` — no value proposition on the most-linked page on the site; passing no title lets `Seo` use its default.

## `Crawl-delay: 1` removed

Google ignores it; **Bing and Yandex honour it**. At one request per second the ~32,000 show pages need **over nine hours** of continuous crawling. It throttles indexing far more than it protects an origin that already sits behind Cloudflare.

## Verified

138 tests pass, production build clean, and against the built app:

```
home    title 'WeebVIP - Track Your Anime Watchlist'   h1 x1  h2 x6
about   title 'About | WeebVIP'                        h1 x1  h2 x6   3,111 chars text
show    title 'The Villager of Level 999 | WeebVIP'    h1 x1  h2 x4
robots.txt — no Crawl-delay, Sitemap intact
```

Worth a click through `/about` and the homepage after merge — the about page in particular now renders server-side for the first time, and the hero heading changed tag (CSS selectors updated to match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
