### PR TITLE
fix: shape meta descriptions properly, and mark Japanese text as Japanese

### DIFF
--- a/src/lib/meta.test.ts
+++ b/src/lib/meta.test.ts
@@ -1,0 +1,56 @@
+import { metaDescription } from './meta';
+
+// The real synopsis that exposed every one of these problems in production.
+const REAL = `The sorcerer Luck believes this to be the end. Besieged by powerful demons, he makes the noble sacrifice of holding back their onslaught while his friends escape.
+
+Following his triumph, Luck soon reunites with his friends.
+
+[Written by MAL Rewrite]`;
+
+describe('metaDescription', () => {
+  it('never cuts mid-word', () => {
+    const out = metaDescription(REAL)!;
+    // Everything before the ellipsis must be whole words.
+    const body = out.replace(/…$/, '');
+    expect(REAL.replace(/\s+/g, ' ')).toContain(body);
+    expect(body.endsWith(' ')).toBe(false);
+  });
+
+  it('collapses the newlines that leaked into the meta tag', () => {
+    expect(metaDescription(REAL)).not.toMatch(/[\n\r]/);
+  });
+
+  it('strips the MyAnimeList attribution', () => {
+    expect(metaDescription(REAL, 500)).not.toContain('[Written by MAL Rewrite]');
+    expect(metaDescription('Short one. [Source: ANN]', 500)).toBe('Short one.');
+  });
+
+  it('adds no ellipsis when nothing was removed', () => {
+    expect(metaDescription('A complete sentence.')).toBe('A complete sentence.');
+    expect(metaDescription('A complete sentence.')).not.toContain('…');
+  });
+
+  it('respects the length budget', () => {
+    const out = metaDescription(REAL, 160)!;
+    expect(out.length).toBeLessThanOrEqual(161); // 160 + the ellipsis character
+  });
+
+  it('does not leave dangling punctuation before the ellipsis', () => {
+    // Cutting right after a comma used to give "…the end,…"
+    const out = metaDescription('one two three, four five six seven', 15)!;
+    expect(out).not.toMatch(/[,\s]…$/);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('hard-cuts rather than returning nothing for one enormous word', () => {
+    const out = metaDescription('x'.repeat(400), 160)!;
+    expect(out.length).toBe(161);
+  });
+
+  it('returns null for empty or missing input', () => {
+    expect(metaDescription(null)).toBeNull();
+    expect(metaDescription(undefined)).toBeNull();
+    expect(metaDescription('')).toBeNull();
+    expect(metaDescription('   ')).toBeNull();
+  });
+});

--- a/src/lib/meta.ts
+++ b/src/lib/meta.ts
@@ -1,0 +1,46 @@
+/**
+ * Meta description shaping.
+ *
+ * The show page used to build its description with `description.substring(0, 160) + '...'`,
+ * which produced three separate problems in the served HTML:
+ *
+ *   - cuts mid-word, so snippets ended "...he makes the noble sacrifi..."
+ *   - keeps the source's newlines, and MyAnimeList synopses are multi-paragraph, so
+ *     raw line breaks ended up inside the meta tag
+ *   - appends "..." even when the text was already complete
+ */
+
+/** MyAnimeList boilerplate, useless in a search snippet. */
+const ATTRIBUTION = /\s*\[(?:written|source)[^\]]*\]\s*$/i;
+
+/** Trailing punctuation that reads badly immediately before an ellipsis. */
+const DANGLING = /[\s,;:.\-–—]+$/;
+
+export const DEFAULT_MAX = 160;
+
+/**
+ * Collapse to a single line, trim to `max` characters on a word boundary, and add an
+ * ellipsis only when something was actually removed.
+ *
+ * Uses the single ellipsis character rather than three dots: search engines count
+ * characters, and it reads the same for two fewer.
+ */
+export function metaDescription(
+  raw: string | null | undefined,
+  max: number = DEFAULT_MAX
+): string | null {
+  if (!raw) return null;
+
+  const text = raw.replace(ATTRIBUTION, '').replace(/\s+/g, ' ').trim();
+  if (!text) return null;
+  if (text.length <= max) return text;
+
+  const slice = text.slice(0, max + 1);
+  const lastSpace = slice.lastIndexOf(' ');
+
+  // Fall back to a hard cut only if the last word is absurdly long — otherwise a
+  // single unbroken string would collapse the description to nothing.
+  const cut = lastSpace > max * 0.5 ? slice.slice(0, lastSpace) : slice.slice(0, max);
+
+  return cut.replace(DANGLING, '') + '…';
+}

--- a/src/routes/show/[id]/+page.server.ts
+++ b/src/routes/show/[id]/+page.server.ts
@@ -4,6 +4,7 @@ import type { PageServerLoad } from './$types';
 // (it already had: missing userAnime.episodes)
 import { getAnimeDetailsByID, queryCharactersAndStaffByAnimeID } from '../../../services/api/graphql/queries';
 import { createSSRGraphQLClient, cookieHeaderFrom, isNotFoundError } from '$lib/server/ssr-graphql';
+import { metaDescription } from '$lib/meta';
 
 export const load: PageServerLoad = async ({ params, locals, cookies }) => {
   const { id } = params;
@@ -41,9 +42,12 @@ export const load: PageServerLoad = async ({ params, locals, cookies }) => {
     if (animeData?.anime) {
       const anime = animeData.anime;
       animeTitle = anime.titleEn || anime.titleJp || 'Anime Details';
-      animeDescription = anime.description
-        ? `${anime.description.substring(0, 160)}...`
-        : `Watch and track ${animeTitle} episodes, get notifications, and manage your anime watchlist on WeebVIP.`;
+      // metaDescription rather than a raw substring: synopses are multi-paragraph, so
+      // the old `substring(0, 160) + '...'` put raw newlines in the tag and cut
+      // mid-word.
+      animeDescription =
+        metaDescription(anime.description) ??
+        `Watch and track ${animeTitle} episodes, get notifications, and manage your anime watchlist on WeebVIP.`;
 
       // Not anime.imageUrl: that is a MyAnimeList address, and wrapping it in the CDN
       // prefix produced a 404 for every anime. /og/<id> resolves the banner, then the

--- a/src/routes/show/[id]/news/+page.svelte
+++ b/src/routes/show/[id]/news/+page.svelte
@@ -162,7 +162,7 @@
           {news.length} {news.length === 1 ? 'story' : 'stories'}
         </span>
         <h1>{data.animeTitle}</h1>
-        {#if data.animeTitleJp}<span class="jp">{data.animeTitleJp}</span>{/if}
+        {#if data.animeTitleJp}<span class="jp" lang="ja">{data.animeTitleJp}</span>{/if}
         <span class="sub">
           {#if getYearUTC(data.anime?.startDate)}{getYearUTC(data.anime.startDate)}{/if}
           {#if studio}<span class="dot">·</span>{studio}{/if}

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -462,7 +462,9 @@
 
           <h1 class="hero-title">{animeTitle}</h1>
           {#if anime.titleJp}
-            <p class="hero-title-jp">{anime.titleJp}</p>
+            <!-- lang="ja": Japanese text inside a lang="en" document. Tells search
+                 engines which language it is, and screen readers which voice to use. -->
+            <p class="hero-title-jp" lang="ja">{anime.titleJp}</p>
           {/if}
 
           <!-- Ranking -->
@@ -692,7 +694,7 @@
             {#if anime.titleJp}
               <div class="info-item">
                 <span class="info-label">Japanese</span>
-                <span class="info-value">{anime.titleJp}</span>
+                <span class="info-value" lang="ja">{anime.titleJp}</span>
               </div>
             {/if}
             {#if anime.titleRomaji}


### PR DESCRIPTION
Items 5 and 6 from the audit — though 5 turned out to need a different fix than I'd listed.

## Meta descriptions

The show page built its description as `description.substring(0, 160) + '...'`, which broke three ways at once:

- MyAnimeList synopses are **multi-paragraph**, so raw newlines went into the meta tag
- the cut landed **mid-word** — snippets ended `"he makes the noble sacrifi..."`
- `'...'` was appended **even when nothing was removed**

```
before  'The sorcerer Luck … he makes the noble '...    163 chars, cut mid-sentence
after   'The sorcerer Luck … while his friends…'        155 chars, whole words
```

`metaDescription()` collapses whitespace, trims on a word boundary, strips the `[Written by MAL Rewrite]` boilerplate that's pure noise in a search snippet, and adds an ellipsis only when it actually truncated. Single ellipsis character rather than three dots, since engines count characters.

8 tests, including the real synopsis that exposed all three problems.

## Language marking — not hreflang

**I listed this as "add hreflang" in the audit, and that was wrong.** hreflang describes *the same content at different URLs per language*. There's one URL per anime here — the EN/JP toggle is a client-side display preference on the same page, not a separate document. hreflang would advertise URLs that don't exist.

The real gap is **element-level `lang`** on Japanese text inside an otherwise English document. Added to the three places `titleJp` renders:

```html
<p class="hero-title-jp" lang="ja">ここは俺に任せて先に行けと言ってから10年がたったら伝説になっていた。</p>
```

That tells search engines which language the string is, and screen readers which voice to use.

**News summaries are deliberately left alone** — `AnimeNews` already documents that the summary is always English and only the *source article* is Japanese, so the language chip there describes the source, not the text on the page. Marking those `lang="ja"` would be actively wrong.

## Verified

146 tests pass (8 new), production build clean, and in the served HTML:

```
description   155 chars, no newlines, ends on a whole word, no MAL attribution
lang="ja"     2 occurrences, both on Japanese title renders
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
