### PR TITLE
feat: give currently-airing anime their own sitemap

### DIFF
--- a/src/lib/server/sitemap.test.ts
+++ b/src/lib/server/sitemap.test.ts
@@ -3,6 +3,7 @@ import {
   chunkCount,
   escapeXml,
   animeEntries,
+  getAiringRecords,
   getAnimeRecords,
   getNewsRecords,
   newsEntries,
@@ -212,6 +213,59 @@ describe('getNewsEntries', () => {
     }));
 
     expect(await getNewsRecords(client)).toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('getAiringRecords', () => {
+  it('unions currentlyAiring with the current season, without duplicates', async () => {
+    const { client, calls } = fakeClient(() => ({
+      currentlyAiring: [
+        { id: 'a', updatedAt: '2026-08-03 04:25:32' },
+        { id: 'b', updatedAt: null }
+      ],
+      // 'b' airs and is in the season; 'c' is in the season but between episodes.
+      animeBySeasons: [
+        { id: 'b', updatedAt: '2026-07-01 00:00:00' },
+        { id: 'c', updatedAt: '2026-07-02 00:00:00' }
+      ]
+    }));
+
+    const records = await getAiringRecords(client, 'SUMMER_2026');
+
+    expect(records.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+    // One round trip: both sets come from a single query.
+    expect(calls).toHaveLength(1);
+  });
+
+  it('keeps the first lastmod seen, so airing data wins over season data', async () => {
+    const { client } = fakeClient(() => ({
+      currentlyAiring: [{ id: 'b', updatedAt: '2026-08-03 04:25:32' }],
+      animeBySeasons: [{ id: 'b', updatedAt: '2026-07-01 00:00:00' }]
+    }));
+
+    const records = await getAiringRecords(client, 'SUMMER_2026');
+
+    expect(records).toEqual([{ id: 'b', lastmod: '2026-08-03' }]);
+  });
+
+  it('passes the season through as a variable', async () => {
+    const { client, calls } = fakeClient(() => ({ currentlyAiring: [], animeBySeasons: [] }));
+
+    await getAiringRecords(client, 'FALL_2026');
+
+    expect(calls[0].vars).toEqual({ season: 'FALL_2026' });
+  });
+
+  it('caches, like the other sitemap sources', async () => {
+    const { client, calls } = fakeClient(() => ({
+      currentlyAiring: [{ id: 'a' }],
+      animeBySeasons: []
+    }));
+
+    await getAiringRecords(client, 'SUMMER_2026');
+    await getAiringRecords(client, 'SUMMER_2026');
+
     expect(calls).toHaveLength(1);
   });
 });

--- a/src/lib/server/sitemap.ts
+++ b/src/lib/server/sitemap.ts
@@ -19,6 +19,10 @@ export const ANIME_PER_SITEMAP = 10_000;
 // cache in front of it is shorter, so a stale sitemap is never served for long.
 const TTL_MS = 6 * 60 * 60 * 1000;
 
+// Shorter: this set turns over as episodes air and seasons roll, and it is the one
+// crawlers are asked to revisit most often, so a stale lastmod here costs more.
+const AIRING_TTL_MS = 60 * 60 * 1000;
+
 export interface SitemapEntry {
   loc: string;
   lastmod?: string | null;
@@ -40,6 +44,7 @@ export interface SitemapRecord {
 
 let animeCache: Cached<SitemapRecord[]> | null = null;
 let newsCache: Cached<SitemapRecord[]> | null = null;
+let airingCache: Cached<SitemapRecord[]> | null = null;
 
 /**
  * The API returns "2026-08-03 04:25:32" — not ISO 8601, and with no zone marker.
@@ -107,6 +112,19 @@ const NEWS_PAGE_QUERY = `
   }
 `;
 
+/**
+ * The anime that matter most right now: airing today, plus everything in the current
+ * season. Two sources because they are not the same set — `currentlyAiring` returned
+ * 48 while the current season holds ~130, so a show between episodes falls out of the
+ * first but not the second.
+ */
+const AIRING_QUERY = `
+  query SitemapAiring($season: Season!) {
+    currentlyAiring(limit: 500) { id updatedAt }
+    animeBySeasons(season: $season, limit: 2000) { id updatedAt }
+  }
+`;
+
 // newestAnime has no pagination, only a limit, so this asks for more than the
 // catalogue holds and takes what comes back. Revisit if the catalogue approaches it.
 const CATALOGUE_CEILING = 100_000;
@@ -128,6 +146,34 @@ export async function getAnimeRecords(client: Client): Promise<SitemapRecord[]> 
     .map((a: any) => ({ id: a.id, lastmod: toLastmod(a.updatedAt) }));
 
   animeCache = { value: records, expires: Date.now() + TTL_MS };
+  return records;
+}
+
+/**
+ * Currently-airing and current-season anime, kept in their own sitemap.
+ *
+ * Note this is NOT done with <priority> or <changefreq>: Google states it ignores
+ * both, so marking these 1.0 would achieve nothing. The value of a separate file is
+ * that Search Console reports coverage per sitemap, so the ~180 pages that matter
+ * this season can be seen to be indexed without their signal drowning in 32,000
+ * others. What actually drives crawl priority is internal linking and an honest
+ * lastmod, not sitemap metadata.
+ */
+export async function getAiringRecords(
+  client: Client,
+  season: string
+): Promise<SitemapRecord[]> {
+  if (airingCache && airingCache.expires > Date.now()) return airingCache.value;
+
+  const res: any = await client.request(AIRING_QUERY, { season });
+
+  const seen = new Map<string, string | null>();
+  for (const a of [...(res?.currentlyAiring ?? []), ...(res?.animeBySeasons ?? [])]) {
+    if (a?.id && !seen.has(a.id)) seen.set(a.id, toLastmod(a.updatedAt));
+  }
+
+  const records = [...seen.entries()].map(([id, lastmod]) => ({ id, lastmod }));
+  airingCache = { value: records, expires: Date.now() + AIRING_TTL_MS };
   return records;
 }
 
@@ -245,4 +291,5 @@ export function xmlResponse(body: string): Response {
 export function _clearSitemapCache(): void {
   animeCache = null;
   newsCache = null;
+  airingCache = null;
 }

--- a/src/routes/sitemap-airing.xml/+server.ts
+++ b/src/routes/sitemap-airing.xml/+server.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from './$types';
+import { createSSRGraphQLClient, getCurrentSeason } from '$lib/server/ssr-graphql';
+import { animeEntries, getAiringRecords, renderUrlset, xmlResponse } from '$lib/server/sitemap';
+
+/**
+ * The anime that matter right now: airing today, plus the current season.
+ *
+ * Separate from the bulk chunks so Search Console reports their indexing coverage on
+ * their own, rather than averaged into 32,000 back-catalogue URLs. Deliberately not
+ * expressed with <priority> or <changefreq> — Google ignores both.
+ *
+ * These URLs also appear in the sitemap-anime-N chunks. That overlap is intentional:
+ * the spec allows a URL in more than one sitemap, Google deduplicates, and per-sitemap
+ * coverage is still reported for each file — so excluding them from the chunks would
+ * add bookkeeping without improving the diagnostic.
+ */
+export const GET: RequestHandler = async ({ locals, url }) => {
+  const client = createSSRGraphQLClient(locals.config.graphql_host, null);
+  const records = await getAiringRecords(client, getCurrentSeason());
+  return xmlResponse(renderUrlset(animeEntries(records, url.origin)));
+};

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -18,6 +18,9 @@ export const GET: RequestHandler = async ({ locals, url }) => {
 
   const children = [
     { loc: `${site}/sitemap-pages.xml` },
+    // Listed before the back catalogue. Ordering carries no documented weight with
+    // Google, but it reflects what a human should look at first in Search Console.
+    { loc: `${site}/sitemap-airing.xml` },
     ...Array.from({ length: chunkCount(anime.length) }, (_, i) => ({
       loc: `${site}/sitemap-anime-${i + 1}.xml`
     })),


### PR DESCRIPTION
The catalogue is ~32,000 pages and only a few hundred matter in any given season, but the sitemap treated them all alike — so there was no way to tell whether the pages that matter were actually being indexed.

## What this does

`sitemap-airing.xml` carries the union of `currentlyAiring` and the current season — **133 URLs today**, all with `lastmod`.

Those are genuinely two different sets: `currentlyAiring` returns **48** while the current season holds **133**, because a show between episodes falls out of the first but not the second. Both come from one query, deduplicated, with the airing record's `lastmod` winning on overlap.

## What this deliberately does *not* do

**No `<priority>` or `<changefreq>`.** Google states it ignores both, so marking these `1.0` would be theatre. The usual "set priority on your important pages" advice is a no-op.

What a separate file actually buys is **diagnosis**: Search Console reports coverage per sitemap, so you can see whether your ~130 seasonal pages are indexed without that signal averaging into 32,000 back-catalogue URLs. What genuinely drives crawl priority is internal linking and an honest `lastmod` — neither of which is a sitemap flag.

**Overlap with the bulk chunks is intentional.** These URLs also appear in `sitemap-anime-N`. The spec allows a URL in several sitemaps, Google deduplicates, and per-sitemap coverage is still reported for each file — so excluding them would add bookkeeping without improving the diagnostic.

Cached for **an hour** rather than six: this set turns over as episodes air and seasons roll, and it's the one crawlers revisit most, so a stale `lastmod` costs more here.

## Verified

150 tests pass (4 new, covering the union, dedup, lastmod precedence, the season variable, and caching). Against a production build hitting the real API:

```
sitemap.xml lists:
  sitemap-pages.xml
  sitemap-airing.xml     ← new, listed before the back catalogue
  sitemap-anime-{1..4}.xml
  sitemap-news.xml

sitemap-airing.xml   valid XML, 133 URLs, 133 with lastmod, 17.1 KB
```

## Worth being clear about the ceiling

This improves *observability*, not ranking. The thing actually holding the catalogue back is that **98.3% of anime have no internal links** — a sitemap tells Google a URL exists, links tell it the URL matters. Browse indexes and related-anime links remain the item that would move the needle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
