### PR TITLE
perf: raise cache TTLs so repeat visits land while entries are still fresh

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -34,6 +34,16 @@ let configData: any = null;
  * Cloudflare's CDN honour. They are deliberately separate: the two shared
  * caches were tuned independently, and the sMaxAge values here preserve what
  * production was already doing rather than quietly retuning it.
+ *
+ * On picking a ttl: freshness comes from purging by tag, not from expiry. An
+ * entry is Fresh for ttl and Stale for the swr window after it, and a stale
+ * serve is fast for the visitor but wakes an SSR pod to revalidate behind it.
+ * Staging's first day ran ttl=60 and measured 5 hits against 5 stales — every
+ * repeat visit landed after the fresh window had closed, so the pod was woken
+ * about as often as with no cache at all and never scaled to zero. A ttl below
+ * the real gap between two visits to the same URL buys latency and throws away
+ * the scale-to-zero the architecture exists for. Prefer a generous ttl and
+ * purge on ingest.
  */
 const CACHEABLE_ROUTES: Array<{
   pattern: RegExp;
@@ -43,12 +53,26 @@ const CACHEABLE_ROUTES: Array<{
   sMaxAge: number;
   tags: (match: RegExpExecArray) => string[];
 }> = [
-  { pattern: /^\/$/,                    ttl: 60,  swr: 600,  maxAge: 300, sMaxAge: 3600, tags: () => ['home'] },
-  { pattern: /^\/airing$/,              ttl: 60,  swr: 600,  maxAge: 300, sMaxAge: 3600, tags: () => ['airing'] },
-  { pattern: /^\/airing\/calendar$/,    ttl: 300, swr: 1800, maxAge: 300, sMaxAge: 1800, tags: () => ['airing'] },
-  { pattern: /^\/season\/([^/]+)$/,     ttl: 300, swr: 1800, maxAge: 300, sMaxAge: 1800, tags: (m) => [`season:${m[1]}`] },
-  { pattern: /^\/show\/([^/]+)$/,       ttl: 60,  swr: 600,  maxAge: 60,  sMaxAge: 600,  tags: (m) => [`show:${m[1]}`] },
-  { pattern: /^\/show\/([^/]+)\/news$/, ttl: 300, swr: 1800, maxAge: 300, sMaxAge: 1800, tags: (m) => [`show:${m[1]}`, 'news'] }
+  // The two genuinely time-sensitive pages: an episode airing changes what they
+  // show. Still five minutes rather than one — nothing here is live to the
+  // second, and the airing sync can purge `airing` when it ingests.
+  { pattern: /^\/$/,                    ttl: 300,  swr: 3600, maxAge: 300, sMaxAge: 3600, tags: () => ['home'] },
+  { pattern: /^\/airing$/,              ttl: 300,  swr: 3600, maxAge: 300, sMaxAge: 3600, tags: () => ['airing'] },
+
+  // A month grid barely moves within a month.
+  { pattern: /^\/airing\/calendar$/,    ttl: 1800, swr: 7200, maxAge: 300, sMaxAge: 1800, tags: () => ['airing'] },
+
+  // Past seasons are effectively immutable; the current one changes about as
+  // fast as the airing list, which its own tag can purge.
+  { pattern: /^\/season\/([^/]+)$/,     ttl: 3600, swr: 7200, maxAge: 300, sMaxAge: 1800, tags: (m) => [`season:${m[1]}`] },
+
+  // A show's synopsis, studio and episode count are close to static — this was
+  // the worst offender at ttl=60, and it is also the largest URL space (~32k),
+  // so it is where repeat visits are furthest apart. Purged by `show:<id>`.
+  { pattern: /^\/show\/([^/]+)$/,       ttl: 3600, swr: 7200, maxAge: 60,  sMaxAge: 600,  tags: (m) => [`show:${m[1]}`] },
+
+  // News arrives in batches from the ingest, which can purge `news`.
+  { pattern: /^\/show\/([^/]+)\/news$/, ttl: 1800, swr: 7200, maxAge: 300, sMaxAge: 1800, tags: (m) => [`show:${m[1]}`, 'news'] }
 ];
 
 function cachePolicyFor(pathname: string) {


### PR DESCRIPTION
## What staging measured

First day on #91, across both edge replicas:

| outcome | count |
|---|---|
| miss | 39 |
| bypass | 28 |
| hit | 5 |
| stale | 5 |
| upstream requests | 69 |

Hits and stales are equal — every repeat visit arrived *after* the 60s fresh window closed and was served `STALE` instead of `HIT`.

## Why that's a problem, given stale is fast

It isn't a latency problem. Stale serves at **22.4ms p95 against 2.42s for a miss**, so visitors are already getting the win.

The cost is on the other side: every stale serve fires a background revalidation that **wakes an SSR pod**. The arithmetic shows it — 39 misses + 28 bypasses = 67, against 69 upstream requests; the remainder are revalidations. The pod still hadn't scaled to zero 16 minutes after deploy.

So at `ttl: 60` the pod was being woken about as often as with no cache at all. That's the scale-to-zero the whole architecture exists for, spent for nothing.

## The fix

Those 60s values came from following the adapter README's example, not from anything true about this site. **Freshness here comes from purging by tag, which is already wired on every entry** — so the ttl only needs to be shorter than how stale we'd tolerate being if a purge were somehow missed, not shorter than how often content changes.

| route | ttl | swr | why |
|---|---|---|---|
| `/` | 60 → **300** | 600 → 3600 | an airing episode genuinely changes it |
| `/airing` | 60 → **300** | 600 → 3600 | same |
| `/airing/calendar` | 300 → **1800** | 1800 → 7200 | a month grid barely moves within a month |
| `/season/<x>` | 300 → **3600** | 1800 → 7200 | past seasons effectively immutable |
| `/show/<id>` | 60 → **3600** | 600 → 7200 | synopsis/studio/episode count are near-static, and at ~32k URLs it's where two visits are furthest apart |
| `/show/<id>/news` | 300 → **1800** | 1800 → 7200 | news arrives in ingest batches |

All well under the adapter's `maxTtl` of 86400, so nothing gets clamped.

## Scope

**Header values (`maxAge`/`sMaxAge`) are untouched**, so Cloudflare production behaviour doesn't move. This retunes only the adapter's Redis cache, which is staging-only today.

Misses will stay high regardless — 39 of 49 cacheable requests were first-touches of a cold URL, and with ~32k show URLs and sparse repeat traffic that's inherent. The value concentrates on hot URLs. What should change is the hit:stale ratio and the number of revalidation wakeups.

`bun run check:gate`: 0 errors, 0 warnings.

## The follow-up that makes this properly safe

Long TTLs are cheap; they're only *correct* if purge-on-ingest is wired. The tags exist on every entry (`show:<id>`, `season:<x>`, `airing`, `news`) and `CACHE_PURGE_TOKEN` is provisioned, but nothing calls the purge API yet — so today a content change waits out the ttl. Worth doing next, in the sync jobs rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)