### PR TITLE
fix: allow jamesat.dev to frame the site, via frame-ancestors

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -212,7 +212,28 @@ export const handle: Handle = async ({ event, resolve }) => {
   if (response.headers) {
     // Security headers
     response.headers.set('X-Content-Type-Options', 'nosniff');
-    response.headers.set('X-Frame-Options', 'DENY');
+
+    /*
+     * Who may frame this site, as an allowlist rather than a flat refusal.
+     *
+     * This replaces `X-Frame-Options: DENY`, which cannot express "nobody
+     * except one origin": its ALLOW-FROM directive was dropped from the spec,
+     * and a browser that meets it ignores the whole header rather than honour
+     * it. CSP's frame-ancestors is the mechanism that survived, and per CSP
+     * Level 3 §6.4.2.2 it "overrides the X-Frame-Options header" — where both
+     * are sent, the old one is ignored. Sending both would therefore be
+     * contradictory rather than belt-and-braces, so it is deliberately gone.
+     *
+     * This is not a relaxation. A page with no frame-ancestors at all may be
+     * framed by anyone, which is the setup a clickjacking attack wants; this
+     * permits exactly two origins and refuses every other site on the internet.
+     * jamesat.dev embeds this app as a window on its desktop.
+     */
+    response.headers.set(
+      'Content-Security-Policy',
+      "frame-ancestors 'self' https://jamesat.dev"
+    );
+
     response.headers.set('X-XSS-Protection', '1; mode=block');
     response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 


### PR DESCRIPTION
`jamesat.dev` opens this app as a window on its desktop, and the frame is
currently refused. This is the smallest correct change to permit it.

### Where the header actually comes from

`src/hooks.server.ts` sets `X-Frame-Options: DENY` on every response. Not
Cloudflare — the edge passes through what the app sends. That hook runs in the
Cloudflare Worker build too, so this one file covers the live path.

Checked and ruled out: there is no `wrangler.toml`, no `_headers` and no
`_routes.json` in the repo, and no other `headers.set` anywhere in the app. This
is the only place these headers are produced.

### Why not just allowlist the origin on the existing header

`X-Frame-Options` cannot express "nobody except one origin". Its `ALLOW-FROM`
directive was dropped, and [per MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options)
a browser that encounters it will "ignore the header completely" — so using it
would leave the site *less* protected, not more. The only two values modern
browsers honour are `DENY` and `SAMEORIGIN`, neither of which fits.

### Why this is not a relaxation

CSP's `frame-ancestors` is the mechanism that replaced it, and per
[CSP Level 3 §6.4.2.2](https://www.w3.org/TR/CSP3/) it "overrides the
`X-Frame-Options` header" — where both are present the old one is ignored, so
sending both would be contradictory rather than belt-and-braces.
`X-Frame-Options` is therefore removed deliberately rather than left alongside.

The result permits exactly two origins and refuses every other site on the
internet. The alternative failure mode — no `frame-ancestors` and no
`X-Frame-Options` — is what a clickjacking attack wants, and this is not that.

```
Content-Security-Policy: frame-ancestors 'self' https://jamesat.dev
```

No other Content-Security-Policy is set anywhere in the app, so nothing is being
overwritten.

### Not touched

`nginx.conf` also sets `X-Frame-Options "SAMEORIGIN"`, but nginx is not in the
serving path — Cloudflare is deployed with wrangler, and the container build
uses `adapter-node` with bun. The live response (`x-sveltekit-page: true`,
`X-Frame-Options: DENY`) matches this hook rather than that file. Left alone
rather than changed speculatively; worth deleting separately if it is dead.

### Verifying after deploy

```sh
curl -sI https://weeb.vip | grep -iE 'frame-ancestors|x-frame-options'
# expect: content-security-policy: frame-ancestors 'self' https://jamesat.dev
# expect: no x-frame-options line
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)