### PR TITLE
fix: stop the page scrolling sideways on mobile

### DIFF
--- a/src/svelte/components/AnimeNews.svelte
+++ b/src/svelte/components/AnimeNews.svelte
@@ -177,7 +177,7 @@
                   >
                     <path d={sourceIcon(ref.url, ref.kind).d} />
                   </svg>
-                  {ref.title}
+                  <span class="ref-title">{ref.title}</span>
                   <span class="ref-host">{hostOf(ref.url)}</span>
                 </a>
               {/each}
@@ -315,6 +315,10 @@
     line-height: 1.38;
     text-wrap: balance;
     transition: color 140ms ease;
+    /* Same min-width:auto trap as .refs — a long unbroken headline (a URL, a
+       romanised title with no spaces) would otherwise widen the 1fr column. */
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .date {
@@ -351,6 +355,9 @@
     flex-wrap: wrap;
     gap: 6px;
     margin-top: 8px;
+    /* Grid items default to min-width:auto, which lets a nowrap chip widen the row
+       past the viewport instead of being clamped by it. */
+    min-width: 0;
   }
 
   .ref {
@@ -364,6 +371,17 @@
     border-radius: 20px;
     padding: 3px 11px 3px 8px;
     white-space: nowrap;
+    /* A chip stays on one line, so on a narrow screen it has to be allowed to
+       shrink and ellipsise its title — otherwise it scrolls the whole page. */
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .ref-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
   }
 
   .ref {
@@ -390,6 +408,7 @@
     font-family: var(--weeb-font-mono);
     font-size: 10px;
     color: var(--weeb-fg-muted);
+    flex: none;
   }
 
   .lang {

--- a/src/svelte/components/ShowContent.svelte
+++ b/src/svelte/components/ShowContent.svelte
@@ -624,7 +624,7 @@
     <nav data-tab-bar bind:this={tabBarEl} aria-label="Section navigation"
       style="position:sticky; top:var(--weeb-nav-height,60px); z-index:50; background:oklch(14% 0.015 275 / 0.95); border-bottom:1px solid oklch(28% 0.015 275); backdrop-filter:blur(12px); -webkit-backdrop-filter:blur(12px); transition:top 0.3s ease;"
     >
-      <div style="max-width:1280px; margin:0 auto; padding:0 48px; display:flex; align-items:center; gap:0;">
+      <div class="tab-bar-inner">
         <button
           style="padding:10px 20px; font-size:13px; font-weight:500; background:none; border:none; cursor:pointer; white-space:nowrap; border-bottom:2px solid {activeTab === 'synopsis' ? 'oklch(55% 0.15 280)' : 'transparent'}; color:{activeTab === 'synopsis' ? 'oklch(95% 0.005 265)' : 'oklch(55% 0.01 270)'};"
           on:click={() => scrollToSection('synopsis')}
@@ -1140,8 +1140,36 @@
   =========================== */
 
   /* ===========================
-     FLOATING TAB BAR — all styles inline in markup to survive ViewTransition CSS loss
+     FLOATING TAB BAR — button styles stay inline in markup (they were written that way
+     to survive Astro's ViewTransition CSS loss). The container lives here because it
+     needs a media query, which an inline style attribute cannot express.
   =========================== */
+  .tab-bar-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 48px;
+    display: flex;
+    align-items: center;
+    gap: 0;
+  }
+
+  /* The tabs are nowrap and there can be four of them with count badges, which is
+     wider than a small phone. Scroll them inside the bar rather than letting them
+     widen the document — an overflowing tab bar scrolls the whole page sideways. */
+  @media (max-width: 768px) {
+    .tab-bar-inner {
+      padding: 0 16px;
+      overflow-x: auto;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }
+    .tab-bar-inner::-webkit-scrollbar {
+      display: none;
+    }
+    .tab-bar-inner > button {
+      flex: none;
+    }
+  }
 
   /* ===========================
      NEXT EPISODE BANNER

--- a/tests/e2e/mobile.spec.ts
+++ b/tests/e2e/mobile.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, devices } from '@playwright/test';
 
+// Same anime as anime-news.spec.ts — hardcoded so the overflow check runs against a
+// show that actually has news and episodes, which is what makes the layout dense.
+const ANIME_WITH_NEWS = 'a8f45313-b080-4f5a-8d53-5d04e7d2a315';
+
 // Mobile-specific tests
 test.describe('Mobile Experience', () => {
   test('mobile navigation and touch interactions', async ({ page, isMobile }) => {
@@ -38,6 +42,65 @@ test.describe('Mobile Experience', () => {
       // Check if content doesn't overflow horizontally
       const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
       expect(bodyWidth).toBeLessThanOrEqual(viewport.width + 20); // Allow small margin
+    }
+  });
+
+  /**
+   * The page must not scroll sideways on a phone. The check above only covers `/` and
+   * allows 20px of slop, which let two real overflows through: the reference chips on
+   * the news page (nowrap, no max-width) and the show-page tab bar (four nowrap tabs
+   * wider than a small phone). Both widened the document itself, so assert on
+   * documentElement.scrollWidth with no tolerance, across the pages that broke.
+   *
+   * 320px is the narrowest viewport worth supporting (iPhone SE); bugs of this class
+   * only show up at the narrow end, which is why the 375px-and-up list above missed them.
+   */
+  test('no horizontal page scroll at 320px', async ({ page }) => {
+    const paths = [
+      '/',
+      '/airing',
+      '/search',
+      `/show/${ANIME_WITH_NEWS}`,
+      `/show/${ANIME_WITH_NEWS}/news`,
+    ];
+
+    await page.setViewportSize({ width: 320, height: 800 });
+
+    // Force the `anime-news` flag on, the same way anime-news.spec.ts does. Without it
+    // the news section may not render at all in some environments, and a page with no
+    // content trivially "passes" an overflow check.
+    await page.addInitScript(() => {
+      const FLAG = 'anime-news';
+      const install = () => {
+        const w = window as any;
+        if (!w.posthog) {
+          w.posthog = { isFeatureEnabled: (key: string) => key === FLAG };
+          return;
+        }
+        if (w.posthog.__flagPatched) return;
+        const original = typeof w.posthog.isFeatureEnabled === 'function'
+          ? w.posthog.isFeatureEnabled.bind(w.posthog)
+          : () => false;
+        w.posthog.isFeatureEnabled = (key: string) => (key === FLAG ? true : original(key));
+        w.posthog.__flagPatched = true;
+      };
+      install();
+      const iv = setInterval(install, 25);
+      setTimeout(() => clearInterval(iv), 10000);
+    });
+
+    for (const path of paths) {
+      await page.goto(path);
+      await page.waitForLoadState('domcontentloaded');
+      // Let async sections (news, episodes) render — they are what overflows.
+      await page.waitForTimeout(2000);
+
+      const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+
+      expect(scrollWidth, `${path} scrolls horizontally at 320px`).toBeLessThanOrEqual(clientWidth);
     }
   });
 


### PR DESCRIPTION
## What

The page could be scrolled horizontally on a phone. Two elements were widening the document past the viewport, and both hit the same CSS trap: nowrap content inside a grid/flex item, where the default `min-width: auto` lets the child size the container rather than the other way round — so the overflow escapes to the document and scrolls the whole page.

**News reference chips** (`AnimeNews.svelte`) — `.ref` chips are `white-space: nowrap` with no max-width, so a single long reference title pushed `/show/[id]/news` 34px wide at a 393px viewport. The chip now shrinks and ellipsises its title. `.title` gets the same guard; it was one long unbroken headline (a URL, a romanised title with no spaces) away from doing the same thing.

**Show-page tab bar** (`ShowContent.svelte`) — four nowrap tabs plus count badges inside 48px of padding is 484px of content at a 320px viewport. Below 768px the padding drops to 16px and the bar scrolls itself instead of the page. Its container moved from an inline style to a class because a media query can't be expressed in a `style` attribute; the button styles stay inline as they were, and the section comment was updated to say so.

## Test

The existing responsive check missed both: it only loaded `/`, allowed 20px of slop, and started at 375px. Bugs of this class only surface at the narrow end.

The new test asserts `documentElement.scrollWidth <= clientWidth` with no tolerance at 320px, across `/`, `/airing`, `/search`, and both show pages. Confirmed it fails without the fixes (484 vs 320) and passes with them.

## Verification

- Swept every main route plus 6 show pages and their news pages at 320px and 393px with a Playwright probe that flags any element overflowing the viewport without a clipping or scrolling ancestor, so real carousels like the airing strip aren't false positives. All clean.
- Re-checked with a probe that bisects the DOM by hiding subtrees, which also catches pseudo-elements — a blind spot in the first probe, since `querySelectorAll` can't see them. Still clean.
- Specifically cleared the "Watch on" streaming tooltips as a suspect: `.platform-link::after` is nowrap, absolutely positioned and only `opacity: 0`, so it would contribute to scrollable overflow — but `section.hero-banner` has `overflow: hidden` and clips it. Verified with the section mocked in, including a worst-case 42-character platform name.
- `yarn check:gate` clean (0 errors / 0 warnings, baseline 0/0); `yarn test` 150 passed.

Screenshots at 320px confirm the tab bar and chips still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)