### PR TITLE
feat: make email verification impossible to miss after signup

### DIFF
--- a/src/routes/auth/check-email/+page.svelte
+++ b/src/routes/auth/check-email/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Seo from '$lib/Seo.svelte';
+  import CheckEmailPage from '../../../svelte/components/CheckEmailPage.svelte';
+</script>
+
+<Seo
+  title="Check your email"
+  description="Confirm your email address to finish setting up your WeebVIP account."
+  noIndex={true}
+/>
+
+<CheckEmailPage />

--- a/src/svelte/components/CheckEmail.svelte
+++ b/src/svelte/components/CheckEmail.svelte
@@ -1,0 +1,459 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import debug from '../../utils/debug';
+  import { emailProviderFor } from '../../utils/email-provider';
+  import { useResendVerificationEmail } from '../services/queries';
+
+  const RESEND_COOLDOWN_SECONDS = 60;
+
+  let email = '';
+  let resendError = '';
+  let resentJustNow = false;
+  let cooldown = 0;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const resendMutation = useResendVerificationEmail();
+
+  // The address arrives as a query param from register, so the form is gone by
+  // the time the user reads this and a typo is still visible and fixable.
+  $: email = $page.url.searchParams.get('email') ?? '';
+  $: provider = emailProviderFor(email);
+
+  onMount(() => {
+    if (!email) {
+      debug.warn('CheckEmail rendered without an email query param');
+    }
+  });
+
+  onDestroy(() => {
+    if (timer) clearInterval(timer);
+  });
+
+  function startCooldown() {
+    cooldown = RESEND_COOLDOWN_SECONDS;
+    if (timer) clearInterval(timer);
+    timer = setInterval(() => {
+      cooldown -= 1;
+      if (cooldown <= 0 && timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    }, 1000);
+  }
+
+  $: if ($resendMutation.isSuccess && !resentJustNow) {
+    debug.success('Verification email resent');
+    resentJustNow = true;
+    resendError = '';
+    startCooldown();
+  }
+
+  $: if ($resendMutation.isError) {
+    debug.error('Failed to resend verification email', $resendMutation.error);
+    resendError = 'We couldn\'t send that again just now. Try once more in a moment.';
+    resentJustNow = false;
+  }
+
+  function handleResend() {
+    if (cooldown > 0 || !email || $resendMutation.isPending) return;
+    resentJustNow = false;
+    resendError = '';
+    $resendMutation.mutate({ username: email });
+  }
+
+  function formatCooldown(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  }
+
+  $: isResending = $resendMutation.isPending;
+</script>
+
+<!-- Animated background -->
+<div class="page-bg"></div>
+
+<main class="main">
+  <div class="auth-wrapper">
+
+    <!-- Logo block -->
+    <a href="/" class="logo-block" aria-label="weeb.vip - back to homepage">
+      <div class="logo-mark">
+        <svg width="24" height="24" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+          <path d="M4 5L8.5 16L11 10L13.5 16L18 5" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="11" cy="11" r="1.2" fill="white" opacity="0.7"/>
+        </svg>
+      </div>
+      <span class="logo-wordmark">weeb.vip</span>
+    </a>
+
+    <!-- Card -->
+    <div class="card">
+      <div class="glyph" aria-hidden="true">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="2.5" y="5" width="19" height="14" rx="2.5"/>
+          <path d="M3 7l9 6 9-6"/>
+        </svg>
+      </div>
+
+      <div class="card-header">
+        <h1 class="card-title">Check your email</h1>
+        <p class="card-subtitle">
+          {#if email}
+            We sent a verification link to<br /><b>{email}</b>
+          {:else}
+            We sent a verification link to the address you signed up with.
+          {/if}
+        </p>
+      </div>
+
+      {#if resentJustNow}
+        <div class="alert alert-success" role="status">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 13l4 4L19 7"/>
+          </svg>
+          <p>Sent again just now — check your inbox.</p>
+        </div>
+      {:else}
+        <ol class="steps">
+          <li><span class="num">1</span><span>Open the email from weeb.vip</span></li>
+          <li><span class="num">2</span><span>Click <em>Verify my email</em></span></li>
+          <li><span class="num">3</span><span>Come back here and log in</span></li>
+        </ol>
+      {/if}
+
+      {#if resendError}
+        <div class="alert alert-error" role="alert">
+          <p>{resendError}</p>
+        </div>
+      {/if}
+
+      {#if provider.url}
+        <a class="btn-primary" href={provider.url} target="_blank" rel="noopener noreferrer">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="5" width="18" height="14" rx="2"/>
+            <path d="M3.5 7l8.5 5.5L20.5 7"/>
+          </svg>
+          {provider.label}
+        </a>
+      {:else}
+        <a class="btn-primary" href="/auth/login">Go to log in</a>
+      {/if}
+
+      <!-- 15 minutes is the token's actual lifetime (exp - iat on the
+           EMAIL_VERIFICATION JWT), not a rounded guess. Say it plainly: a link
+           this short-lived is otherwise a mystery failure. -->
+      <p class="hint">The link expires in 15 minutes. Nothing yet? It's often in spam.</p>
+
+      <div class="resend-row">
+        <span>Didn't get it?</span>
+        {#if cooldown > 0}
+          <span class="countdown" aria-live="polite">Resend in {formatCooldown(cooldown)}</span>
+        {:else}
+          <button type="button" class="link-btn" on:click={handleResend} disabled={isResending || !email}>
+            {isResending ? 'Sending…' : 'Resend email'}
+          </button>
+        {/if}
+      </div>
+
+      <div class="card-footer">
+        Wrong address? <a href="/auth/register">Sign up again</a>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+<style>
+  /* --- Animated background --- */
+  .page-bg {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(135deg,
+      oklch(16% 0.025 280),
+      oklch(14% 0.015 270),
+      oklch(15% 0.02 295));
+    background-size: 400% 400%;
+    animation: bgShift 30s ease infinite;
+  }
+
+  @keyframes bgShift {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+  }
+
+  /* --- Main layout --- */
+  .main {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 16px 40px;
+  }
+
+  .auth-wrapper {
+    width: 100%;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+  }
+
+  /* --- Logo block --- */
+  .logo-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .logo-mark {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--weeb-accent), var(--weeb-violet));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .logo-wordmark {
+    font-family: var(--weeb-font-mono);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--weeb-fg);
+  }
+
+  /* --- Card --- */
+  .card {
+    width: 100%;
+    background: var(--weeb-bg-elevated);
+    border: 1px solid var(--weeb-border);
+    border-radius: var(--weeb-radius-lg);
+    padding: 36px;
+    box-shadow: 0 4px 24px oklch(0% 0 0 / 0.3), 0 1px 3px oklch(0% 0 0 / 0.2);
+  }
+
+  .glyph {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: oklch(55% 0.15 280 / 0.16);
+    color: var(--weeb-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 18px;
+  }
+
+  .card-header {
+    margin-bottom: 22px;
+    text-align: center;
+  }
+
+  .card-title {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--weeb-fg);
+    margin-bottom: 5px;
+  }
+
+  .card-subtitle {
+    font-size: 14px;
+    color: var(--weeb-fg-muted);
+    line-height: 1.5;
+  }
+
+  .card-subtitle b {
+    color: var(--weeb-fg);
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  /* --- Numbered steps --- */
+  .steps {
+    list-style: none;
+    margin: 0 0 22px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  .steps li {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    font-size: 13.5px;
+    color: var(--weeb-fg-secondary);
+    line-height: 1.45;
+  }
+
+  .steps em {
+    color: var(--weeb-fg);
+    font-style: normal;
+  }
+
+  .steps .num {
+    flex-shrink: 0;
+    width: 19px;
+    height: 19px;
+    border-radius: 50%;
+    background: var(--weeb-surface);
+    border: 1px solid var(--weeb-border);
+    color: var(--weeb-fg-muted);
+    font-family: var(--weeb-font-mono);
+    font-size: 10.5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 1px;
+  }
+
+  /* --- Alerts --- */
+  .alert {
+    font-size: 13px;
+    padding: 11px 14px;
+    border-radius: var(--weeb-radius);
+    border: 1px solid;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 20px;
+  }
+
+  .alert p {
+    margin: 0;
+  }
+
+  .alert-success {
+    color: var(--weeb-green);
+    background: oklch(20% 0.03 155 / 0.5);
+    border-color: var(--weeb-green);
+  }
+
+  .alert-error {
+    color: var(--weeb-red);
+    background: oklch(20% 0.03 25 / 0.5);
+    border-color: var(--weeb-red);
+  }
+
+  /* --- Primary action --- */
+  .btn-primary {
+    width: 100%;
+    height: 46px;
+    background: var(--weeb-accent);
+    color: white;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    border: none;
+    border-radius: var(--weeb-radius);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    text-decoration: none;
+    transition: background 0.15s, transform 0.1s;
+  }
+
+  .btn-primary:hover {
+    background: var(--weeb-accent-hover);
+  }
+
+  .btn-primary:active {
+    transform: scale(0.99);
+  }
+
+  .hint {
+    font-size: 12.5px;
+    color: var(--weeb-fg-muted);
+    text-align: center;
+    line-height: 1.5;
+    margin-top: 12px;
+  }
+
+  /* --- Resend row --- */
+  .resend-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border-top: 1px solid var(--weeb-border);
+    margin-top: 20px;
+    padding-top: 16px;
+    font-size: 13.5px;
+    color: var(--weeb-fg-muted);
+  }
+
+  .countdown {
+    font-family: var(--weeb-font-mono);
+    font-size: 12.5px;
+    color: var(--weeb-fg-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .link-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 13.5px;
+    font-family: inherit;
+    font-weight: 500;
+    color: var(--weeb-accent);
+    cursor: pointer;
+    transition: color 0.15s;
+  }
+
+  .link-btn:hover:not(:disabled) {
+    color: var(--weeb-accent-hover);
+    text-decoration: underline;
+  }
+
+  .link-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* --- Card footer --- */
+  .card-footer {
+    text-align: center;
+    font-size: 13px;
+    color: var(--weeb-fg-muted);
+    margin-top: 14px;
+  }
+
+  .card-footer a {
+    color: var(--weeb-accent);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.15s;
+  }
+
+  .card-footer a:hover {
+    color: var(--weeb-accent-hover);
+    text-decoration: underline;
+  }
+
+  /* --- Responsive --- */
+  @media (max-width: 480px) {
+    .main {
+      padding: 40px 16px 24px;
+    }
+    .card {
+      padding: 24px;
+    }
+    .card-title {
+      font-size: 20px;
+    }
+  }
+</style>

--- a/src/svelte/components/CheckEmailPage.svelte
+++ b/src/svelte/components/CheckEmailPage.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { QueryClientProvider } from '@tanstack/svelte-query';
+  import { initializeQueryClient } from '../services/query-client';
+  import CheckEmail from './CheckEmail.svelte';
+
+  const queryClient = initializeQueryClient();
+</script>
+
+<QueryClientProvider client={queryClient}>
+  <CheckEmail />
+</QueryClientProvider>

--- a/src/svelte/components/EmailVerification.svelte
+++ b/src/svelte/components/EmailVerification.svelte
@@ -1,191 +1,465 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import debug from '../../utils/debug';
-  import { useVerifyEmail } from '../services/queries';
+  import { useResendVerificationEmail, useVerifyEmail } from '../services/queries';
 
-  interface VerificationState {
-    loading: boolean;
-    success: boolean;
-    error: string | null;
-  }
+  // No separate 'expired' state: the gateway returns the same
+  // "Access denied" / DOWNSTREAM_SERVICE_ERROR for an expired token, a
+  // malformed one, and one signed by an unknown key. Splitting them would mean
+  // guessing, so the one failure state covers all of them honestly and offers
+  // the same one-tap recovery.
+  type Status = 'loading' | 'success' | 'incomplete' | 'failed';
 
-  let state: VerificationState = {
-    loading: false,
-    success: false,
-    error: null
-  };
+  const REDIRECT_SECONDS = 3;
 
+  let status: Status = 'loading';
   let email: string | null = null;
   let token: string | null = null;
 
-  const verifyEmailMutation = useVerifyEmail();
+  let resendState: 'idle' | 'sending' | 'sent' | 'failed' = 'idle';
+  let redirectIn = REDIRECT_SECONDS;
+  let redirectTimer: ReturnType<typeof setInterval> | undefined;
 
-  // Handle verification state changes. The mutation can resolve with
-  // success=false (verification didn't actually happen), so treat that as an
-  // error rather than showing the success screen.
+  const verifyEmailMutation = useVerifyEmail();
+  const resendMutation = useResendVerificationEmail();
+
+  $: decodedEmail = email ? decodeURIComponent(email) : '';
+  // Verification proves ownership of the address but doesn't return credentials,
+  // so we can't mint a session here — the next best thing is handing login an
+  // email it doesn't have to be typed into.
+  $: loginHref = decodedEmail ? `/auth/login?email=${encodeURIComponent(decodedEmail)}` : '/auth/login';
+
+  // The mutation can resolve with success=false (verification didn't actually
+  // happen), so treat that as a failure rather than showing the success screen.
   $: if ($verifyEmailMutation.isSuccess) {
     if ($verifyEmailMutation.data?.success) {
       debug.success('Email verification successful');
-      state = {
-        loading: false,
-        success: true,
-        error: null
-      };
+      if (status !== 'success') {
+        status = 'success';
+        startRedirect();
+      }
     } else {
       debug.error('Email verification returned unsuccessful');
-      state = {
-        loading: false,
-        success: false,
-        error: 'The verification token may be invalid or have expired. Please request a new verification email.'
-      };
+      status = 'failed';
     }
   }
 
   $: if ($verifyEmailMutation.isError) {
     debug.error('Email verification failed', $verifyEmailMutation.error);
-    state = {
-      loading: false,
-      success: false,
-      error: 'The verification token may be invalid or have expired. Please request a new verification email.'
-    };
+    status = 'failed';
+  }
+
+  $: if ($resendMutation.isSuccess) {
+    resendState = 'sent';
+  }
+
+  $: if ($resendMutation.isError) {
+    debug.error('Failed to resend verification email', $resendMutation.error);
+    resendState = 'failed';
   }
 
   onMount(() => {
-    // Get search params
     const searchParams = new URLSearchParams(window.location.search);
     email = searchParams.get('email');
     token = searchParams.get('token');
 
     if (!email || !token) {
-      state = {
-        loading: false,
-        success: false,
-        error: 'Invalid verification link. Missing email or token.'
-      };
+      status = 'incomplete';
       return;
     }
 
-    // Auto-start verification when component mounts
-    state = { ...state, loading: true };
     $verifyEmailMutation.mutate(token);
   });
 
+  onDestroy(() => {
+    if (redirectTimer) clearInterval(redirectTimer);
+  });
+
+  function startRedirect() {
+    redirectIn = REDIRECT_SECONDS;
+    redirectTimer = setInterval(() => {
+      redirectIn -= 1;
+      if (redirectIn <= 0) {
+        if (redirectTimer) clearInterval(redirectTimer);
+        redirectTimer = undefined;
+        goto(loginHref);
+      }
+    }, 1000);
+  }
+
+  function handleResend() {
+    if (!decodedEmail || $resendMutation.isPending) return;
+    resendState = 'sending';
+    $resendMutation.mutate({ username: decodedEmail });
+  }
+
   function handleRetry() {
-    if (token) {
-      state = { ...state, loading: true, error: null };
-      $verifyEmailMutation.mutate(token);
-    }
+    if (!token) return;
+    status = 'loading';
+    $verifyEmailMutation.mutate(token);
   }
 </script>
 
-<div class="min-h-screen bg-weeb-bg-elevated flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-  <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="flex justify-center">
-      <img
-        class="h-12 w-auto"
-        src="/assets/icons/logo6-rev-sm_sm.png"
-        alt="Weeb VIP"
-        on:error={(e) => {
-          (e.currentTarget as HTMLElement).style.display = 'none';
-        }}
-      />
-    </div>
-    <h2 class="mt-6 text-center text-3xl font-extrabold text-weeb-fg text-weeb-fg">
-      Email Verification
-    </h2>
-    {#if email}
-      <p class="mt-2 text-center text-sm text-weeb-fg-muted">
-        Verifying email address: <span class="font-medium">{decodeURIComponent(email)}</span>
-      </p>
-    {/if}
-  </div>
+<!-- Animated background -->
+<div class="page-bg"></div>
 
-  <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="bg-weeb-surface py-8 px-4 shadow sm:rounded-lg sm:px-10">
-      {#if state.loading}
-        <div class="text-center">
-          <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-weeb-accent"></div>
-          <p class="mt-4 text-sm text-weeb-fg-muted">
-            Verifying your email address...
+<main class="main">
+  <div class="auth-wrapper">
+
+    <!-- Logo block -->
+    <a href="/" class="logo-block" aria-label="weeb.vip - back to homepage">
+      <div class="logo-mark">
+        <svg width="24" height="24" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+          <path d="M4 5L8.5 16L11 10L13.5 16L18 5" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="11" cy="11" r="1.2" fill="white" opacity="0.7"/>
+        </svg>
+      </div>
+      <span class="logo-wordmark">weeb.vip</span>
+    </a>
+
+    <!-- Card -->
+    <div class="card">
+
+      {#if status === 'loading'}
+        <div class="centered">
+          <span class="loader" aria-hidden="true"></span>
+          <h1 class="card-title">Verifying your email</h1>
+          <p class="card-subtitle" aria-live="polite">
+            {#if decodedEmail}Confirming <b>{decodedEmail}</b>…{:else}One moment…{/if}
           </p>
         </div>
       {/if}
 
-      {#if state.success}
-        <div class="text-center">
-          <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-weeb-green/15">
-            <svg
-              class="h-6 w-6 text-weeb-green"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width={2}
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </div>
-          <h3 class="mt-4 text-lg font-medium text-weeb-fg text-weeb-fg">
-            Email Verified Successfully!
-          </h3>
-          <p class="mt-2 text-sm text-weeb-fg-muted">
-            Your email address has been verified. You can now log in to your account.
-          </p>
-          <div class="mt-6">
-            <a
-              href="/auth/login"
-              class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-weeb-accent hover:bg-weeb-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-weeb-accent transition-colors duration-200"
-            >
-              Go to Login
-            </a>
-          </div>
+      {#if status === 'success'}
+        <div class="glyph good" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 13l4 4L19 7"/>
+          </svg>
         </div>
+        <div class="card-header">
+          <h1 class="card-title">You're verified</h1>
+          <p class="card-subtitle">
+            {#if decodedEmail}<b>{decodedEmail}</b> is confirmed and your account is active.
+            {:else}Your email is confirmed and your account is active.{/if}
+          </p>
+        </div>
+        <a class="btn-primary" href={loginHref}>Log in and start tracking</a>
+        <p class="hint" aria-live="polite">Taking you to log in in {redirectIn}…</p>
       {/if}
 
-      {#if state.error}
-        <div class="text-center">
-          <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-weeb-red/15">
-            <svg
-              class="h-6 w-6 text-weeb-red"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </div>
-          <h3 class="mt-4 text-lg font-medium text-weeb-fg text-weeb-fg">
-            Verification Failed
-          </h3>
-          <p class="mt-2 text-sm text-weeb-fg-muted">
-            {state.error}
-          </p>
-          <div class="mt-6 space-y-3">
-            {#if token}
-              <button
-                on:click={handleRetry}
-                class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-weeb-accent hover:bg-weeb-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-weeb-accent transition-colors duration-200"
-              >
-                Try Again
-              </button>
+      {#if status === 'failed'}
+        <div class="glyph stale" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="8.5"/>
+            <path d="M12 7.5V12l3 2"/>
+          </svg>
+        </div>
+        <div class="card-header">
+          <h1 class="card-title">This link didn't work</h1>
+          <p class="card-subtitle">
+            Verification links expire 15 minutes after they're sent.
+            {#if decodedEmail}
+              We can send a fresh one to <b>{decodedEmail}</b>.
+            {:else}
+              Request a new one from the log in page.
             {/if}
-            <a
-              href="/auth/login"
-              class="w-full flex justify-center py-2 px-4 border border-weeb-border rounded-md shadow-sm text-sm font-medium text-weeb-fg-secondary bg-weeb-surface hover:bg-weeb-surface-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-weeb-accent transition-colors duration-200"
-            >
-              Back to Login
-            </a>
+          </p>
+        </div>
+
+        {#if resendState === 'sent'}
+          <div class="alert alert-success" role="status">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M5 13l4 4L19 7"/>
+            </svg>
+            <p>New link sent — check your inbox, and your spam folder.</p>
           </div>
+        {:else if decodedEmail}
+          {#if resendState === 'failed'}
+            <div class="alert alert-error" role="alert">
+              <p>We couldn't send that just now. Try again in a moment.</p>
+            </div>
+          {/if}
+          <button
+            type="button"
+            class="btn-primary"
+            on:click={handleResend}
+            disabled={resendState === 'sending'}
+          >
+            {resendState === 'sending' ? 'Sending…' : 'Send a new link'}
+          </button>
+        {/if}
+
+        <p class="hint">Your account and password are unchanged.</p>
+
+        <div class="secondary-actions">
+          {#if token}
+            <button type="button" class="btn-ghost" on:click={handleRetry}>Try this link again</button>
+          {/if}
+          <a class="btn-ghost" href="/auth/login">Back to log in</a>
         </div>
       {/if}
+
+      {#if status === 'incomplete'}
+        <div class="glyph bad" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </div>
+        <div class="card-header">
+          <h1 class="card-title">This link is incomplete</h1>
+          <p class="card-subtitle">
+            Some email clients cut long links in half. Open the message again and
+            use the <em>Verify my email</em> button rather than copying the address.
+          </p>
+        </div>
+
+        <div class="secondary-actions">
+          <a class="btn-ghost" href="/auth/resend-verification">Send me a new link</a>
+          <a class="btn-ghost" href="/auth/login">Back to log in</a>
+        </div>
+      {/if}
+
     </div>
+
   </div>
-</div>
+</main>
+
+<style>
+  /* --- Animated background --- */
+  .page-bg {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(135deg,
+      oklch(16% 0.025 280),
+      oklch(14% 0.015 270),
+      oklch(15% 0.02 295));
+    background-size: 400% 400%;
+    animation: bgShift 30s ease infinite;
+  }
+
+  @keyframes bgShift {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+  }
+
+  /* --- Main layout --- */
+  .main {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 16px 40px;
+  }
+
+  .auth-wrapper {
+    width: 100%;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+  }
+
+  /* --- Logo block --- */
+  .logo-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .logo-mark {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--weeb-accent), var(--weeb-violet));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .logo-wordmark {
+    font-family: var(--weeb-font-mono);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--weeb-fg);
+  }
+
+  /* --- Card --- */
+  .card {
+    width: 100%;
+    background: var(--weeb-bg-elevated);
+    border: 1px solid var(--weeb-border);
+    border-radius: var(--weeb-radius-lg);
+    padding: 36px;
+    box-shadow: 0 4px 24px oklch(0% 0 0 / 0.3), 0 1px 3px oklch(0% 0 0 / 0.2);
+  }
+
+  .centered {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 6px;
+  }
+
+  .card-header {
+    margin-bottom: 22px;
+    text-align: center;
+  }
+
+  .card-title {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--weeb-fg);
+    margin-bottom: 5px;
+  }
+
+  .card-subtitle {
+    font-size: 14px;
+    color: var(--weeb-fg-muted);
+    line-height: 1.5;
+  }
+
+  .card-subtitle b {
+    color: var(--weeb-fg);
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  /* --- Status glyphs --- */
+  .glyph {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 18px;
+  }
+
+  .glyph.good  { background: oklch(65% 0.15 155 / 0.15); color: var(--weeb-green); }
+  .glyph.stale { background: oklch(72% 0.14 85 / 0.15);  color: var(--weeb-amber); }
+  .glyph.bad   { background: oklch(60% 0.18 25 / 0.15);  color: var(--weeb-red); }
+
+  /* --- Loader --- */
+  .loader {
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--weeb-border);
+    border-top-color: var(--weeb-accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin-bottom: 14px;
+  }
+
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loader { animation-duration: 2s; }
+    .page-bg { animation: none; }
+  }
+
+  /* --- Alerts --- */
+  .alert {
+    font-size: 13px;
+    padding: 11px 14px;
+    border-radius: var(--weeb-radius);
+    border: 1px solid;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+
+  .alert p { margin: 0; }
+
+  .alert-success {
+    color: var(--weeb-green);
+    background: oklch(20% 0.03 155 / 0.5);
+    border-color: var(--weeb-green);
+  }
+
+  .alert-error {
+    color: var(--weeb-red);
+    background: oklch(20% 0.03 25 / 0.5);
+    border-color: var(--weeb-red);
+  }
+
+  /* --- Buttons --- */
+  .btn-primary {
+    width: 100%;
+    height: 46px;
+    background: var(--weeb-accent);
+    color: white;
+    font-size: 15px;
+    font-weight: 600;
+    font-family: inherit;
+    letter-spacing: 0.01em;
+    border: none;
+    border-radius: var(--weeb-radius);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 9px;
+    text-decoration: none;
+    transition: background 0.15s, transform 0.1s;
+  }
+
+  .btn-primary:hover:not(:disabled) { background: var(--weeb-accent-hover); }
+  .btn-primary:active:not(:disabled) { transform: scale(0.99); }
+  .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .secondary-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 14px;
+  }
+
+  .btn-ghost {
+    width: 100%;
+    height: 42px;
+    background: var(--weeb-surface);
+    color: var(--weeb-fg-secondary);
+    font-size: 14px;
+    font-weight: 500;
+    font-family: inherit;
+    border: 1px solid var(--weeb-border);
+    border-radius: var(--weeb-radius);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .btn-ghost:hover {
+    background: var(--weeb-surface-hover);
+    color: var(--weeb-fg);
+  }
+
+  .hint {
+    font-size: 12.5px;
+    color: var(--weeb-fg-muted);
+    text-align: center;
+    line-height: 1.5;
+    margin-top: 12px;
+  }
+
+  /* --- Responsive --- */
+  @media (max-width: 480px) {
+    .main { padding: 40px 16px 24px; }
+    .card { padding: 24px; }
+    .card-title { font-size: 20px; }
+  }
+</style>

--- a/src/svelte/components/Login.svelte
+++ b/src/svelte/components/Login.svelte
@@ -6,27 +6,66 @@
   let hydrated = false;
   onMount(() => { hydrated = true; });
 
+  import { page } from '$app/stores';
   import FormInput from './FormInput.svelte';
   import type { LoginInput } from '../../gql/graphql';
   import debug from '../../utils/debug';
-  import { useLogin } from '../services/queries';
+  import { isUnverifiedEmailError } from '../../utils/auth-errors';
+  import { useLogin, useResendVerificationEmail } from '../services/queries';
 
   let formData: LoginInput = { username: '', password: '' };
   let errorMessage = '';
+  // set instead of errorMessage when the account exists but isn't verified —
+  // the password is fine, so saying "check your credentials" sends people off
+  // to reset a password that was never wrong
+  let needsVerification = false;
+  let resendState: 'idle' | 'sending' | 'sent' | 'failed' = 'idle';
 
   const loginMutation = useLogin();
+  const resendMutation = useResendVerificationEmail();
+
+  // Arriving from the verification success screen, which can't mint a session
+  // itself — pre-fill so only the password is left to type.
+  onMount(() => {
+    const prefill = $page.url.searchParams.get('email');
+    if (prefill) {
+      formData = { ...formData, username: prefill };
+    }
+  });
 
   // Handle login state changes
   $: if ($loginMutation.isSuccess) {
     debug.auth('Login successful');
     errorMessage = '';
+    needsVerification = false;
     // Navigate to home page
     goto('/');
   }
 
   $: if ($loginMutation.isError) {
     debug.error('Login failed', $loginMutation.error);
-    errorMessage = 'Unable to sign in. Please check your credentials and try again.';
+    if (isUnverifiedEmailError($loginMutation.error)) {
+      needsVerification = true;
+      errorMessage = '';
+    } else {
+      needsVerification = false;
+      errorMessage = 'Unable to sign in. Please check your credentials and try again.';
+    }
+  }
+
+  $: if ($resendMutation.isSuccess) {
+    resendState = 'sent';
+  }
+
+  $: if ($resendMutation.isError) {
+    debug.error('Failed to resend verification email', $resendMutation.error);
+    resendState = 'failed';
+  }
+
+  function handleResend() {
+    if (!formData.username.trim() || $resendMutation.isPending) return;
+    resendState = 'sending';
+    $resendMutation.mutate({ username: formData.username });
   }
 
   function handleInputChange(event: CustomEvent) {
@@ -46,6 +85,11 @@
     if (errorMessage) {
       errorMessage = '';
     }
+    // Editing the email invalidates the banner it was addressed to
+    if (needsVerification && name === 'username') {
+      needsVerification = false;
+      resendState = 'idle';
+    }
   }
 
   function handleSubmit(event: Event) {
@@ -57,6 +101,8 @@
     }
 
     errorMessage = '';
+    needsVerification = false;
+    resendState = 'idle';
 
     // Use the reactive mutation pattern like the modal
     $loginMutation.mutate(formData);
@@ -126,6 +172,41 @@
         {#if errorMessage}
           <div class="error-banner">
             <p>{errorMessage}</p>
+          </div>
+        {/if}
+
+        <!-- Unverified account: nothing is wrong, there's just a step left -->
+        {#if needsVerification}
+          <div class="verify-banner" role="alert">
+            <div class="verify-head">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="2.5" y="5" width="19" height="14" rx="2.5"/>
+                <path d="M3 7l9 6 9-6"/>
+              </svg>
+              Verify your email to continue
+            </div>
+            <!-- Deliberately does not assert the account exists: the backend
+                 returns INACTIVE_CREDENTIALS for an unknown address too, so
+                 claiming "we sent you a link" would be wrong for a typo — and
+                 would turn login into a user-enumeration oracle. -->
+            <p class="verify-body">
+              Accounts need a verified email before you can log in. Check
+              <b>{formData.username}</b> for the link we sent — it's often in spam.
+            </p>
+            {#if resendState === 'sent'}
+              <p class="verify-sent">Sent — check your inbox, and your spam folder.</p>
+            {:else if resendState === 'failed'}
+              <p class="verify-failed">We couldn't send that just now. Try again in a moment.</p>
+            {:else}
+              <button
+                type="button"
+                class="verify-action"
+                on:click={handleResend}
+                disabled={resendState === 'sending'}
+              >
+                {resendState === 'sending' ? 'Sending…' : 'Send a new link'}
+              </button>
+            {/if}
           </div>
         {/if}
 
@@ -305,6 +386,77 @@
     font-size: 13px;
     color: var(--weeb-red);
     margin: 0;
+  }
+
+  /* --- Unverified-account banner --- */
+  /* Amber, not red: the credentials were correct, there's just a step left. */
+  .verify-banner {
+    background: oklch(22% 0.04 85 / 0.45);
+    border: 1.5px solid var(--weeb-amber);
+    border-radius: var(--weeb-radius);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+  }
+
+  .verify-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--weeb-amber);
+  }
+
+  .verify-body {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--weeb-fg-secondary);
+    margin: 0;
+  }
+
+  .verify-body b {
+    color: var(--weeb-fg);
+    font-weight: 600;
+    word-break: break-all;
+  }
+
+  .verify-action {
+    align-self: flex-start;
+    background: var(--weeb-amber);
+    color: oklch(20% 0.04 85);
+    font-size: 12.5px;
+    font-weight: 700;
+    font-family: inherit;
+    padding: 7px 13px;
+    border: none;
+    border-radius: var(--weeb-radius-sm);
+    cursor: pointer;
+    transition: filter 0.15s;
+  }
+
+  .verify-action:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+
+  .verify-action:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .verify-sent,
+  .verify-failed {
+    font-size: 12.5px;
+    margin: 0;
+  }
+
+  .verify-sent {
+    color: var(--weeb-green);
+  }
+
+  .verify-failed {
+    color: var(--weeb-red);
   }
 
   /* --- Remember me / Forgot row --- */

--- a/src/svelte/components/LoginRegisterModal.svelte
+++ b/src/svelte/components/LoginRegisterModal.svelte
@@ -5,8 +5,10 @@
   let hydrated = false;
   onMount(() => { hydrated = true; });
 
+  import { goto } from '$app/navigation';
   import type { LoginInput } from "../../gql/graphql";
-  import { useLogin, useRegister } from '../services/queries';
+  import { isUnverifiedEmailError } from '../../utils/auth-errors';
+  import { useLogin, useRegister, useResendVerificationEmail } from '../services/queries';
   import { loggedInStore, loginModalStore } from '../stores/auth';
   import FormInput from './FormInput.svelte';
 
@@ -20,11 +22,16 @@
     confirmPassword: "", // for registration validation
   };
   let errorMessage = "";
-  let successMessage = "";
   let validationErrors: Record<string, string> = {};
+  // login failed because the account exists but isn't verified — see Login.svelte
+  let needsVerification = false;
+  let resendState: 'idle' | 'sending' | 'sent' | 'failed' = 'idle';
+  // kept so the post-register redirect can carry the address
+  let submittedEmail = "";
 
   const loginMutation = useLogin();
   const registerMutation = useRegister();
+  const resendMutation = useResendVerificationEmail();
 
   // Subscribe to login modal state
   onMount(() => {
@@ -43,6 +50,7 @@
       id: $loginMutation.data.id
     });
     errorMessage = "";
+    needsVerification = false;
 
     // Dispatch custom event to trigger data refresh
     console.log('🎉 Login successful - dispatching loginSuccess event');
@@ -54,17 +62,42 @@
   }
 
   $: if ($loginMutation.isError) {
-    errorMessage = 'Unable to sign in. Please check your credentials and try again.';
+    if (isUnverifiedEmailError($loginMutation.error)) {
+      needsVerification = true;
+      errorMessage = "";
+    } else {
+      needsVerification = false;
+      errorMessage = 'Unable to sign in. Please check your credentials and try again.';
+    }
   }
 
-  // Handle register state changes
+  // Registration leaves the modal for the dedicated "check your email" screen,
+  // so the modal path doesn't diverge from /auth/register.
   $: if ($registerMutation.isSuccess) {
     errorMessage = "";
-    successMessage = "Registration successful! Please check your email to verify your account before logging in.";
+    const email = submittedEmail;
+    if (closeFn) {
+      closeFn();
+    }
+    goto(`/auth/check-email?email=${encodeURIComponent(email)}`);
   }
 
   $: if ($registerMutation.isError) {
     errorMessage = 'Unable to create account. Please try again.';
+  }
+
+  $: if ($resendMutation.isSuccess) {
+    resendState = 'sent';
+  }
+
+  $: if ($resendMutation.isError) {
+    resendState = 'failed';
+  }
+
+  function handleResend() {
+    if (!formData.username.trim() || $resendMutation.isPending) return;
+    resendState = 'sending';
+    $resendMutation.mutate({ username: formData.username });
   }
 
   function validateForm() {
@@ -105,8 +138,10 @@
     if (errorMessage) {
       errorMessage = "";
     }
-    if (successMessage) {
-      successMessage = "";
+    // Editing the email invalidates the banner it was addressed to
+    if (needsVerification && field === 'username') {
+      needsVerification = false;
+      resendState = 'idle';
     }
   }
 
@@ -116,6 +151,10 @@
     if (!validateForm()) {
       return;
     }
+
+    needsVerification = false;
+    resendState = 'idle';
+    submittedEmail = formData.username;
 
     const data: LoginInput = { username: formData.username, password: formData.password };
 
@@ -129,7 +168,8 @@
   function toggleMode() {
     isRegisterState = !isRegisterState;
     errorMessage = "";
-    successMessage = "";
+    needsVerification = false;
+    resendState = 'idle';
     validationErrors = {};
   }
 
@@ -161,10 +201,31 @@
       <p>{errorMessage}</p>
     </div>
   {/if}
-  {#if successMessage}
-    <div class="alert alert-success">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="16 12 12 16 8 12"/></svg>
-      <p>{successMessage}</p>
+  {#if needsVerification}
+    <div class="verify-banner" role="alert">
+      <div class="verify-head">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2.5" y="5" width="19" height="14" rx="2.5"/><path d="M3 7l9 6 9-6"/></svg>
+        Verify your email to continue
+      </div>
+      <!-- See Login.svelte: must not assert the account exists. -->
+      <p class="verify-body">
+        Accounts need a verified email before you can log in. Check
+        <b>{formData.username}</b> for the link we sent — it's often in spam.
+      </p>
+      {#if resendState === 'sent'}
+        <p class="verify-sent">Sent — check your inbox, and your spam folder.</p>
+      {:else if resendState === 'failed'}
+        <p class="verify-failed">We couldn't send that just now. Try again in a moment.</p>
+      {:else}
+        <button
+          type="button"
+          class="verify-action"
+          on:click={handleResend}
+          disabled={resendState === 'sending'}
+        >
+          {resendState === 'sending' ? 'Sending…' : 'Send a new link'}
+        </button>
+      {/if}
     </div>
   {/if}
 
@@ -238,12 +299,9 @@
 
   </form>
 
-  <!-- Login-only: resend verification -->
-  {#if !isRegisterState}
-    <div class="resend-link">
-      <a href="/auth/resend-verification" on:click={() => handleLinkClick(closeFn)} class="link-accent">Resend email verification</a>
-    </div>
-  {/if}
+  <!-- No standing "resend verification" link: an unverified login now surfaces
+       the banner above, which resends to the address already typed in.
+       /auth/resend-verification stays reachable for anyone who needs it. -->
 
   <!-- Divider -->
   <div class="divider">
@@ -316,10 +374,70 @@
     background: oklch(20% 0.03 25 / 0.5);
     border-color: oklch(60% 0.18 25 / 0.4);
   }
-  :global(.weeb-auth-modal .alert-success) {
+  /* Unverified-account banner — amber, not red: the credentials were correct,
+     there's just a step left. Mirrors Login.svelte. */
+  :global(.weeb-auth-modal .verify-banner) {
+    background: oklch(22% 0.04 85 / 0.45);
+    border: 1.5px solid var(--weeb-amber);
+    border-radius: var(--weeb-radius, 8px);
+    padding: 12px 14px;
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+  }
+  :global(.weeb-auth-modal .verify-head) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--weeb-amber);
+  }
+  :global(.weeb-auth-modal .verify-head svg) {
+    flex-shrink: 0;
+  }
+  :global(.weeb-auth-modal .verify-body) {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--weeb-fg-secondary);
+    margin: 0;
+  }
+  :global(.weeb-auth-modal .verify-body b) {
+    color: var(--weeb-fg);
+    font-weight: 600;
+    word-break: break-all;
+  }
+  :global(.weeb-auth-modal .verify-action) {
+    align-self: flex-start;
+    background: var(--weeb-amber);
+    color: oklch(20% 0.04 85);
+    font-size: 12.5px;
+    font-weight: 700;
+    font-family: inherit;
+    padding: 7px 13px;
+    border: none;
+    border-radius: var(--weeb-radius-sm, 4px);
+    cursor: pointer;
+    transition: filter 0.15s;
+  }
+  :global(.weeb-auth-modal .verify-action:hover:not(:disabled)) {
+    filter: brightness(1.08);
+  }
+  :global(.weeb-auth-modal .verify-action:disabled) {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  :global(.weeb-auth-modal .verify-sent),
+  :global(.weeb-auth-modal .verify-failed) {
+    font-size: 12.5px;
+    margin: 0;
+  }
+  :global(.weeb-auth-modal .verify-sent) {
     color: var(--weeb-green);
-    background: oklch(20% 0.03 155 / 0.5);
-    border-color: oklch(65% 0.15 155 / 0.4);
+  }
+  :global(.weeb-auth-modal .verify-failed) {
+    color: var(--weeb-red);
   }
 
   /* Form */
@@ -421,12 +539,6 @@
   }
   @keyframes -global-weeb-auth-spin {
     to { transform: rotate(360deg); }
-  }
-
-  /* Resend verification link */
-  :global(.weeb-auth-modal .resend-link) {
-    text-align: center;
-    margin-top: 12px;
   }
 
   /* Divider */

--- a/src/svelte/components/Register.svelte
+++ b/src/svelte/components/Register.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   // until hydration completes, a submit would be a native form POST
   // that sveltekit rejects (no form actions) — keep the button inert
   let hydrated = false;
@@ -16,17 +17,21 @@
     confirmPassword: ''
   };
   let errorMessage = '';
-  let successMessage = '';
   let validationErrors: Record<string, string> = {};
+  // the address submitted, kept so the redirect can carry it even though the
+  // form is cleared before navigation
+  let submittedEmail = '';
 
   const registerMutation = useRegister();
 
-  // Handle register state changes
+  // Registration succeeds into a dedicated screen rather than an inline alert
+  // under an emptied form — the verification step was too easy to miss there.
   $: if ($registerMutation.isSuccess) {
     debug.success('Registration successful!');
     errorMessage = '';
-    successMessage = 'Registration successful! Please check your email to verify your account before logging in.';
+    const email = submittedEmail;
     formData = { username: '', password: '', confirmPassword: '' };
+    goto(`/auth/check-email?email=${encodeURIComponent(email)}`);
   }
 
   $: if ($registerMutation.isError) {
@@ -46,7 +51,6 @@
     }
 
     errorMessage = errorMsg;
-    successMessage = '';
   }
 
   function validateForm() {
@@ -95,9 +99,6 @@
     if (errorMessage) {
       errorMessage = '';
     }
-    if (successMessage) {
-      successMessage = '';
-    }
   }
 
   function handleSubmit(event: Event) {
@@ -108,7 +109,7 @@
     }
 
     errorMessage = '';
-    successMessage = '';
+    submittedEmail = formData.username;
     const data: RegisterInput = { username: formData.username, password: formData.password };
 
     // Use the reactive mutation pattern like the modal
@@ -157,6 +158,9 @@
             error={validationErrors.username}
             required
           />
+          {#if !validationErrors.username}
+            <p class="field-hint">We'll send a link here to confirm it's yours.</p>
+          {/if}
         </div>
 
         <!-- Password -->
@@ -210,12 +214,6 @@
         {#if errorMessage}
           <div class="alert alert-error">
             <p>{errorMessage}</p>
-          </div>
-        {/if}
-
-        {#if successMessage}
-          <div class="alert alert-success">
-            <p>{successMessage}</p>
           </div>
         {/if}
 
@@ -416,10 +414,12 @@
     border-color: var(--weeb-red, oklch(60% 0.18 25));
   }
 
-  .alert-success {
-    color: var(--weeb-green);
-    background: oklch(20% 0.03 155 / 0.5);
-    border-color: var(--weeb-green);
+  /* --- Field hint --- */
+  .field-hint {
+    font-size: 12px;
+    color: var(--weeb-fg-muted);
+    line-height: 1.45;
+    margin-top: 6px;
   }
 
   /* --- Submit button --- */

--- a/src/utils/__tests__/auth-errors.test.ts
+++ b/src/utils/__tests__/auth-errors.test.ts
@@ -1,0 +1,86 @@
+import { isInvalidCredentialsError, isUnverifiedEmailError } from '../auth-errors';
+
+/**
+ * Fixtures are the literal responses returned by the staging gateway
+ * (gateway.staging.weeb.vip) — captured rather than invented, because the
+ * useful code is nested two levels below a top-level message that says nothing.
+ */
+function gatewayError(code: string, message: string) {
+  return {
+    // graphql-request's ClientError shape
+    message: `Failed to fetch from Subgraph 'auth-staging'.: ${JSON.stringify({ response: { errors: [] } })}`,
+    response: {
+      errors: [
+        {
+          message: "Failed to fetch from Subgraph 'auth-staging'.",
+          extensions: {
+            errors: [
+              { message, path: ['CreateSession'], extensions: { code } },
+            ],
+            serviceName: 'auth-staging',
+          },
+        },
+      ],
+      data: { CreateSession: null },
+    },
+  };
+}
+
+const INACTIVE = gatewayError('INACTIVE_CREDENTIALS', 'credentials are not active');
+const INVALID = gatewayError('INVALID_CREDENTIALS', 'invalid credentials');
+
+describe('isUnverifiedEmailError', () => {
+  it('matches the nested INACTIVE_CREDENTIALS code the gateway actually returns', () => {
+    expect(isUnverifiedEmailError(INACTIVE)).toBe(true);
+  });
+
+  it('does not match a wrong password on a verified account', () => {
+    expect(isUnverifiedEmailError(INVALID)).toBe(false);
+  });
+
+  // ClientError stringifies the whole response into .message, so the matcher
+  // still works if the structured `response` is lost in transit.
+  it('falls back to the stringified message when response is absent', () => {
+    expect(isUnverifiedEmailError(new Error(JSON.stringify(INACTIVE.response)))).toBe(true);
+    expect(isUnverifiedEmailError(new Error('credentials are not active'))).toBe(true);
+  });
+
+  it('returns false for unrelated failures', () => {
+    expect(isUnverifiedEmailError(new Error('network error'))).toBe(false);
+    expect(isUnverifiedEmailError(new Error(''))).toBe(false);
+    expect(isUnverifiedEmailError(null)).toBe(false);
+    expect(isUnverifiedEmailError(undefined)).toBe(false);
+    expect(isUnverifiedEmailError({})).toBe(false);
+  });
+
+  it('does not blow up on deeply nested or cyclic-looking structures', () => {
+    const deep: any = { response: { errors: [{ extensions: { errors: [{ extensions: { errors: [] } }] } }] } };
+    expect(isUnverifiedEmailError(deep)).toBe(false);
+  });
+});
+
+describe('isInvalidCredentialsError', () => {
+  it('matches INVALID_CREDENTIALS', () => {
+    expect(isInvalidCredentialsError(INVALID)).toBe(true);
+  });
+
+  it('does not match the unverified case', () => {
+    expect(isInvalidCredentialsError(INACTIVE)).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isInvalidCredentialsError(null)).toBe(false);
+    expect(isInvalidCredentialsError(undefined)).toBe(false);
+  });
+});
+
+// The two branches drive different UI and must never both be true.
+describe('the two classifications are mutually exclusive', () => {
+  it.each([
+    ['inactive', INACTIVE],
+    ['invalid', INVALID],
+  ])('%s matches exactly one classifier', (_label, error) => {
+    const hits = [isUnverifiedEmailError(error), isInvalidCredentialsError(error)].filter(Boolean);
+    expect(hits).toHaveLength(1);
+  });
+});

--- a/src/utils/__tests__/email-provider.test.ts
+++ b/src/utils/__tests__/email-provider.test.ts
@@ -1,0 +1,46 @@
+import { emailProviderFor } from '../email-provider';
+
+describe('emailProviderFor', () => {
+  it('resolves known providers to a labelled webmail link', () => {
+    expect(emailProviderFor('james@gmail.com')).toEqual({
+      label: 'Open Gmail',
+      url: expect.stringContaining('mail.google.com'),
+    });
+    expect(emailProviderFor('james@outlook.com').label).toBe('Open Outlook');
+    expect(emailProviderFor('james@proton.me').label).toBe('Open Proton Mail');
+    expect(emailProviderFor('james@icloud.com').label).toBe('Open iCloud Mail');
+  });
+
+  it('treats provider aliases as the same provider', () => {
+    expect(emailProviderFor('a@hotmail.com').url).toBe(emailProviderFor('b@live.com').url);
+    expect(emailProviderFor('a@me.com').url).toBe(emailProviderFor('b@icloud.com').url);
+  });
+
+  it('is case- and whitespace-insensitive on the domain', () => {
+    expect(emailProviderFor('James@GMAIL.com').label).toBe('Open Gmail');
+    expect(emailProviderFor('james@gmail.com ').label).toBe('Open Gmail');
+  });
+
+  it('splits on the last @ so plus-addressing and quoted locals still resolve', () => {
+    expect(emailProviderFor('james+anime@gmail.com').label).toBe('Open Gmail');
+    expect(emailProviderFor('"odd@local"@gmail.com').label).toBe('Open Gmail');
+  });
+
+  // A wrong deep link is worse than none — unknown domains get a label with no
+  // URL, and the UI falls back to a plain "go to log in" action.
+  it('falls back to a generic label with no link for unknown domains', () => {
+    expect(emailProviderFor('james@jamesat.dev')).toEqual({
+      label: 'Open your email app',
+      url: null,
+    });
+    expect(emailProviderFor('someone@self-hosted.internal').url).toBeNull();
+  });
+
+  it('falls back for missing, empty or malformed addresses', () => {
+    expect(emailProviderFor(null).url).toBeNull();
+    expect(emailProviderFor(undefined).url).toBeNull();
+    expect(emailProviderFor('').url).toBeNull();
+    expect(emailProviderFor('not-an-email').url).toBeNull();
+    expect(emailProviderFor('trailing@').url).toBeNull();
+  });
+});

--- a/src/utils/auth-errors.ts
+++ b/src/utils/auth-errors.ts
@@ -1,0 +1,82 @@
+/**
+ * Auth error classification.
+ *
+ * The gateway federates the auth service, so the useful error is nested two
+ * levels down and the top-level message is always the useless
+ * "Failed to fetch from Subgraph 'auth-staging'.". The real signal lives at
+ * `errors[].extensions.errors[].extensions.code`. Observed codes:
+ *
+ *   INACTIVE_CREDENTIALS  — account exists but is unverified, OR the account
+ *                           doesn't exist at all (deliberately collapsed by the
+ *                           backend so login can't be used to enumerate users)
+ *   INVALID_CREDENTIALS   — account is verified, password is wrong
+ *   DOWNSTREAM_SERVICE_ERROR / "Access denied"
+ *                         — a verification token that is expired, malformed, or
+ *                           signed by an unknown key. These are NOT
+ *                           distinguishable from each other.
+ *
+ * graphql-request's ClientError also embeds the whole JSON response in its
+ * `.message`, so the raw-string fallback below still matches when the
+ * structured `response` isn't present (e.g. a re-thrown or serialised error).
+ */
+
+/** Collect every GraphQL error code in a response, at any nesting depth. */
+function collectCodes(node: any, out: Set<string>, depth = 0): void {
+  if (!node || depth > 6) return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) collectCodes(item, out, depth + 1);
+    return;
+  }
+
+  if (typeof node !== 'object') return;
+
+  const code = node?.extensions?.code;
+  if (typeof code === 'string') out.add(code.toUpperCase());
+
+  collectCodes(node.errors, out, depth + 1);
+  collectCodes(node?.extensions?.errors, out, depth + 1);
+}
+
+function codesOf(error: any): Set<string> {
+  const codes = new Set<string>();
+  collectCodes(error?.response?.errors ?? error?.errors, codes);
+  return codes;
+}
+
+function messageOf(error: any): string {
+  return String(error?.message ?? error ?? '').toLowerCase();
+}
+
+/**
+ * True when a login failed because the credentials aren't active — in practice,
+ * an account whose email has never been verified.
+ *
+ * Note this also fires for an address that was never registered, because the
+ * backend returns the same code for both. Copy at the call site must therefore
+ * not assert that the account exists.
+ */
+export function isUnverifiedEmailError(error: any): boolean {
+  if (codesOf(error).has('INACTIVE_CREDENTIALS')) return true;
+
+  const msg = messageOf(error);
+  if (!msg) return false;
+
+  return (
+    msg.includes('inactive_credentials') ||
+    msg.includes('credentials are not active')
+  );
+}
+
+/**
+ * True when a login failed on a verified account with the wrong password.
+ * Kept alongside the above so the two cases can never both be true.
+ */
+export function isInvalidCredentialsError(error: any): boolean {
+  if (codesOf(error).has('INVALID_CREDENTIALS')) return true;
+
+  const msg = messageOf(error);
+  if (!msg) return false;
+
+  return msg.includes('invalid_credentials') || msg.includes('invalid credentials');
+}

--- a/src/utils/email-provider.ts
+++ b/src/utils/email-provider.ts
@@ -1,0 +1,57 @@
+/**
+ * Resolves an email address to a deep link into its webmail inbox, so the
+ * "check your email" screen can offer a one-tap way back to the message
+ * instead of leaving the user to find it themselves.
+ *
+ * Unknown domains (self-hosted, corporate, anything not listed) fall back to
+ * a generic label with no link — a wrong guess is worse than no button.
+ */
+
+export interface EmailProvider {
+  /** Button label, e.g. "Open Gmail" */
+  label: string;
+  /** Webmail URL, or null when the domain isn't recognised */
+  url: string | null;
+}
+
+const GENERIC: EmailProvider = { label: 'Open your email app', url: null };
+
+// Search URLs where the provider supports them, so the user lands on the
+// verification email rather than an inbox they still have to scan.
+const PROVIDERS: Record<string, EmailProvider> = {
+  'gmail.com': { label: 'Open Gmail', url: 'https://mail.google.com/mail/u/0/#search/from%3Aweeb.vip' },
+  'googlemail.com': { label: 'Open Gmail', url: 'https://mail.google.com/mail/u/0/#search/from%3Aweeb.vip' },
+  'outlook.com': { label: 'Open Outlook', url: 'https://outlook.live.com/mail/0/inbox' },
+  'hotmail.com': { label: 'Open Outlook', url: 'https://outlook.live.com/mail/0/inbox' },
+  'live.com': { label: 'Open Outlook', url: 'https://outlook.live.com/mail/0/inbox' },
+  'msn.com': { label: 'Open Outlook', url: 'https://outlook.live.com/mail/0/inbox' },
+  'yahoo.com': { label: 'Open Yahoo Mail', url: 'https://mail.yahoo.com/d/search/keyword=weeb.vip' },
+  'yahoo.co.uk': { label: 'Open Yahoo Mail', url: 'https://mail.yahoo.com/d/search/keyword=weeb.vip' },
+  'ymail.com': { label: 'Open Yahoo Mail', url: 'https://mail.yahoo.com/d/search/keyword=weeb.vip' },
+  'icloud.com': { label: 'Open iCloud Mail', url: 'https://www.icloud.com/mail' },
+  'me.com': { label: 'Open iCloud Mail', url: 'https://www.icloud.com/mail' },
+  'mac.com': { label: 'Open iCloud Mail', url: 'https://www.icloud.com/mail' },
+  'proton.me': { label: 'Open Proton Mail', url: 'https://mail.proton.me/u/0/all-mail' },
+  'protonmail.com': { label: 'Open Proton Mail', url: 'https://mail.proton.me/u/0/all-mail' },
+  'pm.me': { label: 'Open Proton Mail', url: 'https://mail.proton.me/u/0/all-mail' },
+  'fastmail.com': { label: 'Open Fastmail', url: 'https://app.fastmail.com/mail/Inbox' },
+  'zoho.com': { label: 'Open Zoho Mail', url: 'https://mail.zoho.com/zm/#mail/folder/inbox' },
+  'aol.com': { label: 'Open AOL Mail', url: 'https://mail.aol.com' },
+  'gmx.com': { label: 'Open GMX', url: 'https://www.gmx.com/mail' },
+  'gmx.net': { label: 'Open GMX', url: 'https://www.gmx.net/mail' },
+  'mail.com': { label: 'Open Mail.com', url: 'https://www.mail.com/int/mail' },
+  'yandex.com': { label: 'Open Yandex Mail', url: 'https://mail.yandex.com' },
+  'yandex.ru': { label: 'Open Yandex Mail', url: 'https://mail.yandex.ru' },
+};
+
+export function emailProviderFor(address: string | null | undefined): EmailProvider {
+  if (!address) return GENERIC;
+
+  const at = address.lastIndexOf('@');
+  if (at === -1) return GENERIC;
+
+  const domain = address.slice(at + 1).trim().toLowerCase();
+  if (!domain) return GENERIC;
+
+  return PROVIDERS[domain] ?? GENERIC;
+}

--- a/tests/e2e/add-to-list.spec.ts
+++ b/tests/e2e/add-to-list.spec.ts
@@ -34,9 +34,10 @@ test.describe('Add to list (logged in)', () => {
     const verificationLink = extractVerificationLink(email.HTML || email.Text || '', baseUrl);
     expect(verificationLink).toBeTruthy();
     await page.goto(verificationLink!, { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.getByText(/verified successfully|verification failed/i).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: /you're verified|this link didn't work/i })).toBeVisible({ timeout: 20000 });
 
-    // Login
+    // Login. The verification screen auto-bounces here after a few seconds, so
+    // navigate explicitly to avoid racing that redirect mid-fill.
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForAuthForm(page);
     await page.fill('input[name="username"]', testEmail);

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -194,10 +194,14 @@ export function extractVerificationLink(emailContent: string, baseUrl: string): 
 
 
 /**
- * Register a new account from /auth/register and wait for the success
- * message. The staging registration endpoint is intermittently slow under
- * parallel-shard load, so the submit is retried once if the confirmation
- * doesn't appear — this is the single most common source of e2e flake.
+ * Register a new account from /auth/register and wait for the redirect to the
+ * "check your email" screen, which is now how a successful signup confirms
+ * itself (it used to be an inline alert under the emptied form).
+ *
+ * The staging registration endpoint is intermittently slow under parallel-shard
+ * load, so the submit is retried once if the redirect doesn't happen — this is
+ * the single most common source of e2e flake. The retry re-checks the URL
+ * first, so a slow-but-successful redirect is never double-submitted.
  */
 export async function registerNewUser(page: Page, email: string, password: string) {
   await page.goto('/auth/register', { waitUntil: 'domcontentloaded', timeout: 60000 });
@@ -220,18 +224,31 @@ export async function registerNewUser(page: Page, email: string, password: strin
     { timeout: 15000 }
   );
 
-  const success = page.locator('text=/registration.*successful|check.*email/i');
   for (let attempt = 0; attempt < 2; attempt++) {
-    await submitButton.click();
+    if (page.url().includes('/auth/check-email')) break;
     try {
-      await success.waitFor({ state: 'visible', timeout: 20000 });
-      return;
+      // The button disables itself while the mutation is in flight. Waiting for
+      // it to be actionable means a merely-slow first submit is never retried
+      // against a disabled button, which otherwise hangs until the test timeout.
+      await expect(submitButton).toBeEnabled({ timeout: 30000 });
+      await submitButton.click({ timeout: 10000 });
+    } catch {
+      // Either we navigated away (button detached) or it never settled — the
+      // URL check below decides which.
+    }
+    try {
+      await page.waitForURL(/\/auth\/check-email/, { timeout: 25000 });
+      break;
     } catch {
       if (attempt === 0) {
         // eslint-disable-next-line no-console
-        console.log('Registration confirmation not shown, retrying submit...');
+        console.log('Registration redirect did not happen, retrying submit...');
       }
     }
   }
-  await expect(success).toBeVisible({ timeout: 20000 });
+
+  await expect(page).toHaveURL(/\/auth\/check-email/, { timeout: 20000 });
+  await expect(page.getByRole('heading', { name: /check your email/i })).toBeVisible({ timeout: 15000 });
+  // The address must be on screen — that's the whole point of the screen.
+  await expect(page.getByText(email, { exact: false }).first()).toBeVisible({ timeout: 10000 });
 }

--- a/tests/e2e/profile.spec.ts
+++ b/tests/e2e/profile.spec.ts
@@ -32,9 +32,10 @@ test.describe('Profile page (logged in)', () => {
     const verificationLink = extractVerificationLink(email.HTML || email.Text || '', baseUrl);
     expect(verificationLink).toBeTruthy();
     await page.goto(verificationLink!, { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.getByText(/verified successfully|verification failed/i).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: /you're verified|this link didn't work/i })).toBeVisible({ timeout: 20000 });
 
-    // Login
+    // Login. The verification screen auto-bounces here after a few seconds, so
+    // navigate explicitly to avoid racing that redirect mid-fill.
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForAuthForm(page);
     await page.fill('input[name="username"]', testEmail);

--- a/tests/e2e/registration-direct.spec.ts
+++ b/tests/e2e/registration-direct.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 import { waitForAuthForm, deleteEmailsForRecipient, registerNewUser } from './helpers';
 
-// This is an alternative test that navigates directly to the login page
+// This is an alternative test that navigates directly to the auth pages
 // instead of using the modal, in case the modal has issues
 
 test.describe('User Registration Flow (Direct Navigation)', () => {
@@ -26,28 +26,83 @@ test.describe('User Registration Flow (Direct Navigation)', () => {
   });
 
   test('register user via direct navigation', async ({ page }) => {
-    // Register (helper waits out hydration and retries the submit under
-    // staging registration flake)
+    // Register (helper waits out hydration, retries the submit under staging
+    // registration flake, and asserts the check-email redirect)
     await registerNewUser(page, testEmail, testPassword);
     console.log('Registration successful!');
 
-    // Verify we're not automatically logged in
+    // Verify we're not automatically logged in — verification still gates login
     const profileLink = page.locator('a[href="/profile"], [data-testid="user-menu"]');
     const isLoggedIn = await profileLink.count() > 0;
     expect(isLoggedIn).toBe(false);
     console.log('Confirmed: User is not automatically logged in after registration');
   });
 
-  test('verify resend verification page works', async ({ page }) => {
-    // Navigate directly to resend verification page
+  test('register page sets the expectation before submitting', async ({ page }) => {
+    await page.goto('/auth/register', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForAuthForm(page);
+
+    // The helper line under the email field is what makes the next screen
+    // expected rather than a surprise
+    await expect(page.getByText(/send a link here to confirm/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('check-email screen offers recovery without retyping the address', async ({ page }) => {
+    await registerNewUser(page, testEmail, testPassword);
+
+    // The address is on screen, so a typo is visible and fixable
+    await expect(page.getByText(testEmail, { exact: false }).first()).toBeVisible();
+
+    // The short token lifetime is stated, not left as a mystery failure
+    await expect(page.getByText(/expires in 15 minutes/i)).toBeVisible();
+    await expect(page.getByText(/spam/i).first()).toBeVisible();
+
+    // And the way out of a typo is one click, not a support ticket
+    await expect(page.getByRole('link', { name: /sign up again/i })).toHaveAttribute('href', '/auth/register');
+  });
+
+  test('check-email screen degrades gracefully with no email in the URL', async ({ page }) => {
+    // Someone lands here from history or a shared link
+    await page.goto('/auth/check-email', { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    await expect(page.getByRole('heading', { name: /check your email/i })).toBeVisible({ timeout: 15000 });
+    // Without an address there is nothing to resend to, so the primary action
+    // must fall back to something that still works
+    await expect(page.getByRole('link', { name: /go to log in/i })).toBeVisible();
+  });
+
+  test('a broken verification link explains itself and offers a new one', async ({ page }) => {
+    // The gateway can't distinguish an expired token from a malformed one —
+    // both come back as "Access denied" — so there is one honest failure state.
+    await page.goto(
+      `/auth/verification?email=${encodeURIComponent(testEmail)}&token=not-a-real-token`,
+      { waitUntil: 'domcontentloaded', timeout: 60000 }
+    );
+
+    await expect(page.getByRole('heading', { name: /this link didn't work/i })).toBeVisible({ timeout: 25000 });
+    await expect(page.getByText(/expire 15 minutes/i)).toBeVisible();
+    // Recovery uses the address already in the URL
+    await expect(page.getByRole('button', { name: /send a new link/i })).toBeVisible();
+    await expect(page.getByText(/account and password are unchanged/i)).toBeVisible();
+  });
+
+  test('a truncated verification link is called out as truncated', async ({ page }) => {
+    // Email clients cut long links; without a token there is nothing to verify
+    // and no point pretending the server rejected it.
+    await page.goto('/auth/verification', { waitUntil: 'domcontentloaded', timeout: 60000 });
+
+    await expect(page.getByRole('heading', { name: /this link is incomplete/i })).toBeVisible({ timeout: 20000 });
+    await expect(page.getByRole('link', { name: /send me a new link/i })).toBeVisible();
+  });
+
+  test('verify resend verification page still works', async ({ page }) => {
+    // The standalone page is no longer linked from the login form, but stays
+    // reachable for anyone who has it bookmarked or arrives from an old email.
     await page.goto('/auth/resend-verification', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForAuthForm(page);
-    await page.waitForTimeout(2000);
 
-    // Check page loaded correctly
     await expect(page.locator('h2:has-text("Resend Email Verification")')).toBeVisible();
 
-    // Fill in email
     const emailInput = page.locator('input[type="email"], input[name="username"]').first();
     await emailInput.waitFor({ state: 'visible' });
     await emailInput.fill(testEmail);
@@ -59,7 +114,7 @@ test.describe('User Registration Flow (Direct Navigation)', () => {
 
     // Should see either success or error message
     const messageSelector = page.locator('text=/sent|check.*inbox|not found|already verified/i');
-    await expect(messageSelector).toBeVisible({ timeout: 15000 });
+    await expect(messageSelector.first()).toBeVisible({ timeout: 15000 });
     console.log('Resend verification page is working');
   });
 });

--- a/tests/e2e/registration.spec.ts
+++ b/tests/e2e/registration.spec.ts
@@ -35,24 +35,34 @@ async function openRegisterModal(page: Page): Promise<Locator> {
   return dialog;
 }
 
+// Registering from the modal now closes it and navigates to /auth/check-email,
+// so the modal path and the /auth/register path end in the same place.
 async function fillAndSubmitRegister(dialog: Locator, page: Page, email: string, password: string) {
   // Staging's registration endpoint intermittently drops the request under
-  // parallel-shard load; retry the submit once if the success confirmation
-  // doesn't appear in the modal.
-  const success = dialog.locator('text=/registration.*successful/i');
+  // parallel-shard load; retry the submit once if the redirect doesn't happen.
+  const submit = dialog.locator('form button[type="submit"]');
   for (let attempt = 0; attempt < 2; attempt++) {
-    await dialog.locator('input[name="username"]').fill(email);
-    await dialog.locator('input[name="password"]').fill(password);
-    await dialog.locator('input[name="confirmPassword"]').fill(password);
-    await dialog.locator('form button[type="submit"]').evaluate((btn) => (btn as HTMLButtonElement).click());
+    if (page.url().includes('/auth/check-email')) break;
     try {
-      await success.waitFor({ state: 'visible', timeout: 20000 });
-      return;
+      // See helpers.registerNewUser: the submit button disables itself while the
+      // mutation is in flight, so a slow first submit must not be retried
+      // against a disabled button.
+      await expect(submit).toBeEnabled({ timeout: 30000 });
+      await dialog.locator('input[name="username"]').fill(email);
+      await dialog.locator('input[name="password"]').fill(password);
+      await dialog.locator('input[name="confirmPassword"]').fill(password);
+      await submit.evaluate((btn) => (btn as HTMLButtonElement).click());
     } catch {
-      if (attempt === 0) console.log('Registration confirmation not shown in modal, retrying submit...');
+      // navigated away (modal closed / inputs detached) or never settled
+    }
+    try {
+      await page.waitForURL(/\/auth\/check-email/, { timeout: 25000 });
+      break;
+    } catch {
+      if (attempt === 0) console.log('Registration redirect did not happen from modal, retrying submit...');
     }
   }
-  await expect(success).toBeVisible({ timeout: 20000 });
+  await expect(page).toHaveURL(/\/auth\/check-email/, { timeout: 20000 });
 }
 
 test.describe('User Registration Flow', () => {
@@ -82,9 +92,10 @@ test.describe('User Registration Flow', () => {
     const dialog = await openRegisterModal(page);
     await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
 
-    // Success message is rendered inside the modal
-    await expect(dialog.locator('text=/registration.*successful/i')).toBeVisible({ timeout: 30000 });
-    console.log('Registration successful, checking for verification email...');
+    // Registration now lands on a dedicated screen that names the address
+    await expect(page.getByRole('heading', { name: /check your email/i })).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(testEmail, { exact: false }).first()).toBeVisible({ timeout: 10000 });
+    console.log('Landed on check-email screen, waiting for verification email...');
 
     const email = await getLatestEmail(testEmail);
     expect(email).toBeTruthy();
@@ -99,17 +110,17 @@ test.describe('User Registration Flow', () => {
     await page.goto(verificationLink!, { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForPageReady(page);
 
-    // Wait for the verification page to render and resolve
-    await expect(page.getByRole('heading', { name: /Email Verification/i })).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(/verified successfully|verification failed/i).first())
-      .toBeVisible({ timeout: 15000 });
-    console.log('Email verification page loaded');
+    // Success screen, then an automatic bounce to login with the email pre-filled.
+    // (Verification can't mint a session — the mutation returns success + userID
+    // only — so pre-filling is the closest we get to not making them retype.)
+    await expect(page.getByRole('heading', { name: /you're verified/i })).toBeVisible({ timeout: 20000 });
+    console.log('Email verified');
 
-    // Try to login with verified account on /auth/login
-    await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForURL(/\/auth\/login/, { timeout: 20000 });
     await waitForAuthForm(page);
+    await expect(page.locator('input[name="username"]')).toHaveValue(testEmail, { timeout: 10000 });
+    console.log('Bounced to login with the email pre-filled');
 
-    await page.fill('input[name="username"]', testEmail);
     await page.fill('input[name="password"]', testPassword);
     await page.locator('form button[type="submit"]').first().click();
 
@@ -118,46 +129,54 @@ test.describe('User Registration Flow', () => {
     console.log('Login successful - registration flow complete!');
   });
 
-  test('resend verification email', async ({ page }) => {
+  test('resend verification email from the check-email screen', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForHomepage(page);
 
     const dialog = await openRegisterModal(page);
     await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
 
-    await expect(dialog.locator('text=/registration.*successful/i')).toBeVisible({ timeout: 30000 });
+    // Consume the signup email so the one we assert on below is the resent one
+    await getLatestEmail(testEmail);
+    await deleteEmailsForRecipient(testEmail);
 
-    // Navigate to resend verification page
-    await page.goto('/auth/resend-verification', { waitUntil: 'domcontentloaded', timeout: 60000 });
-    await waitForAuthForm(page);
+    // Resend without retyping the address — it travels in the URL
+    const resendButton = page.getByRole('button', { name: /resend email/i });
+    await resendButton.waitFor({ state: 'visible', timeout: 15000 });
+    await resendButton.click();
 
-    await page.fill('input[name="username"], input[type="email"]', testEmail);
-
-    // Wait for button to be ready and use evaluate for reliable click
-    const submitBtn = page.getByRole('button', { name: /send verification email/i });
-    await submitBtn.waitFor({ state: 'visible' });
-    await submitBtn.evaluate((btn) => (btn as HTMLButtonElement).click());
-
-    // The resend page shows: "Verification email sent! Please check your inbox and spam folder."
-    await expect(page.getByText(/verification email sent|check your inbox/i).first())
-      .toBeVisible({ timeout: 15000 });
-    console.log('Resend verification email successful');
+    await expect(page.getByText(/sent again just now/i)).toBeVisible({ timeout: 15000 });
+    console.log('Resend confirmed in place');
 
     const email = await getLatestEmail(testEmail);
     expect(email).toBeTruthy();
     console.log('Resent verification email received');
   });
 
-  test('prevent login before email verification', async ({ page }) => {
+  test('resend is rate-limited by a visible countdown', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForHomepage(page);
 
     const dialog = await openRegisterModal(page);
     await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
 
-    await expect(dialog.locator('text=/registration.*successful/i')).toBeVisible({ timeout: 30000 });
+    await page.getByRole('button', { name: /resend email/i }).click();
+    await expect(page.getByText(/sent again just now/i)).toBeVisible({ timeout: 15000 });
 
-    // Try to login without verification
+    // A countdown replaces the button, so repeat taps can't fan out N emails
+    await expect(page.getByText(/resend in \d+:\d{2}/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /resend email/i })).toHaveCount(0);
+    console.log('Resend cooldown is shown and the button is gone');
+  });
+
+  test('unverified login is blocked and explains why', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+
+    const dialog = await openRegisterModal(page);
+    await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
+
+    // Try to login without verifying
     await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
     await waitForAuthForm(page);
 
@@ -165,11 +184,69 @@ test.describe('User Registration Flow', () => {
     await page.fill('input[name="password"]', testPassword);
     await page.locator('form button[type="submit"]').first().click();
 
-    // Login should fail. The login form shows a generic credential error.
-    // Verify we did NOT navigate away from /auth/login AND an error banner is shown.
-    await expect(page.getByText(/unable to sign in|check your credentials/i).first())
-      .toBeVisible({ timeout: 10000 });
+    // The gateway returns INACTIVE_CREDENTIALS here, which the login form now
+    // renders as a verification prompt instead of a credential error.
+    await expect(page.getByText(/verify your email to continue/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/verified email before you can log in/i)).toBeVisible();
+    // The old copy blamed the password and sent people off to reset it
+    await expect(page.getByText(/check your credentials/i)).toHaveCount(0);
     expect(page.url()).toContain('/auth/login');
-    console.log('Login correctly blocked for unverified email');
+    console.log('Login correctly blocked with a verification prompt');
+  });
+
+  test('the blocked-login banner resends without retyping the address', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+
+    const dialog = await openRegisterModal(page);
+    await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
+
+    await getLatestEmail(testEmail);
+    await deleteEmailsForRecipient(testEmail);
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForAuthForm(page);
+    await page.fill('input[name="username"]', testEmail);
+    await page.fill('input[name="password"]', testPassword);
+    await page.locator('form button[type="submit"]').first().click();
+
+    const resend = page.getByRole('button', { name: /send a new link/i });
+    await resend.waitFor({ state: 'visible', timeout: 15000 });
+    await resend.click();
+
+    await expect(page.getByText(/sent — check your inbox/i)).toBeVisible({ timeout: 15000 });
+
+    const email = await getLatestEmail(testEmail);
+    expect(email).toBeTruthy();
+    console.log('Resent from the login banner without leaving the page');
+  });
+
+  test('a wrong password on a verified account still says the credentials are wrong', async ({ page }) => {
+    // Guards the branch: INVALID_CREDENTIALS must NOT render the verification
+    // prompt, or we would tell someone to check their email over a typo.
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForHomepage(page);
+
+    const dialog = await openRegisterModal(page);
+    await fillAndSubmitRegister(dialog, page, testEmail, testPassword);
+
+    const email = await getLatestEmail(testEmail);
+    const baseUrl = page.url().match(/^https?:\/\/[^\/]+/)?.[0] || 'http://localhost:4321';
+    const verificationLink = extractVerificationLink(email.HTML || email.Text || '', baseUrl);
+    expect(verificationLink).toBeTruthy();
+
+    await page.goto(verificationLink!, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await expect(page.getByRole('heading', { name: /you're verified/i })).toBeVisible({ timeout: 20000 });
+
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await waitForAuthForm(page);
+    await page.fill('input[name="username"]', testEmail);
+    await page.fill('input[name="password"]', 'definitely-the-wrong-password');
+    await page.locator('form button[type="submit"]').first().click();
+
+    await expect(page.getByText(/unable to sign in|check your credentials/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/verify your email to continue/i)).toHaveCount(0);
+    expect(page.url()).toContain('/auth/login');
+    console.log('Verified account with a bad password gets the credential error, not the verify prompt');
   });
 });


### PR DESCRIPTION
Signing up ended on the page it started, with a one-line green alert under an emptied form. The address was never shown, so a typo was unrecoverable, and coming back to log in produced `Unable to sign in. Please check your credentials.` — blaming a password that was never wrong.

**Verification stays a hard gate on login.** What changes is that every state around it now says what happened and offers the next step.

Mockups and design rationale: https://claude.ai/code/artifact/ab7dacc0-58ac-4416-8650-c6f1ad3507da

## What changes

| Screen | Change |
|---|---|
| `/auth/register` | One helper line under the email field. Success redirects instead of rendering an inline alert. |
| `/auth/check-email` **(new)** | Names the address, deep-links to the user's webmail where the domain is recognised, states the expiry, points at the spam folder, resends behind a 60s countdown, and offers "Sign up again" for a typo. |
| `/auth/login` | Branches on `INACTIVE_CREDENTIALS` and shows an amber verification prompt with an inline resend, using the address already typed in. Pre-fills from `?email=`. |
| `/auth/verification` | Rebuilt on the same card treatment as login and register — it was still on the old Tailwind look. Inline resend on failure; success carries the address to login. |
| Auth modal | Follows the same paths so it can't diverge from the full pages. The standing "Resend email verification" footer link is gone. |

## Three things the gateway corrected

Error shapes were captured from `gateway.staging.weeb.vip` rather than guessed, which changed the design:

- **The useful code is nested** at `errors[].extensions.errors[].extensions.code`. The top-level message is always `"Failed to fetch from Subgraph 'auth-staging'."`, so a naive `error.message` match would never have fired.
- **`INACTIVE_CREDENTIALS` is overloaded.** It's returned for an unverified account, for an address that never registered, *and* for a wrong password on an unverified account. So the banner names the rule ("accounts need a verified email before you can log in") instead of claiming "we sent *you* a link" — which would be false for a typo, and would turn login into a user-enumeration oracle. `INVALID_CREDENTIALS` (verified account, wrong password) keeps the existing credential error, and there's an e2e test guarding that branch specifically.
- **Expired and malformed links are indistinguishable** — both come back as `Access denied` / `DOWNSTREAM_SERVICE_ERROR`. They share one failure state that leads with expiry without claiming it. A link with *no token at all* gets its own screen, since a truncated email is a different fix.

## Two things scaled back

- **Verification can't sign the user in.** `VerifyEmailWithUser` returns only `success` and `userID`, no credentials. The success screen bounces to login after 3s with `?email=` attached and the form pre-fills, so only the password is left to type. If the auth service ever returns credentials, this screen can drop straight into the app.
- **Token lifetime is 15 minutes**, read off `exp - iat` on the JWT — not the 24 hours the first draft assumed. The copy says 15 minutes. That's short enough that it's plausibly a cause of "my link didn't work" on its own, and may be worth raising on the backend. Nothing here is blocked on it.

## Tests

- Unit coverage for both new utils (`auth-errors`, `email-provider`), with the error fixtures captured from the real gateway rather than invented.
- 13 e2e cases across the two registration specs: the check-email redirect, resend + cooldown, blocked login, resend from the banner, both verification failure states, and the guard that a verified account with a bad password still gets the credential error.
- Fixes a retry loop in `registerNewUser` that clicked a still-disabled submit button and hung until the test timeout under load.
- `svelte-check` clean at the 0/0 baseline; 166 unit tests pass; full 46-case Playwright suite passes at CI settings (`--workers=1 --retries=2`).

## Note

An early local e2e run registered a handful of throwaway `uuid@weeb.vip` accounts against **production** — a local `yarn build` defaults to the production config, and a stale preview server kept serving it after a staging rebuild. They're unverified and inert, but they exist. CI is unaffected; it builds with `APP_CONFIG=staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
